### PR TITLE
🐛 show emoji icon

### DIFF
--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -87,7 +87,7 @@ class GitmojiCli {
 				choices: gitmojis.map(gitmoji => {
 					return {
 						name: `${gitmoji.emoji}  - ${gitmoji.description}`,
-						value: gitmoji.code
+						value: gitmoji.emoji
 					};
 				})
 			},


### PR DESCRIPTION
Signed-off-by: zhangliang <55269778@qq.com>

Solve the problem of not displaying icons in the tower / sourcetree / git log

example:
![bug](http://7wy48o.com1.z0.glb.clouddn.com/2016-11-24_10:51:37.jpg)
