### PR TITLE
Fix default behaviour and display help if invalid args

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -41,28 +41,16 @@ const gitmojiApiClient = axios.create({
 
 const gitmojiCli = new GitmojiCli(gitmojiApiClient);
 
-if (cli.flags.list) {
-	gitmojiCli.list();
-}
+const commands = {
+	list: () => gitmojiCli.list(),
+	search: () => cli.input.map(element => gitmojiCli.search(element)),
+	init: () => gitmojiCli.init(),
+	hook: () => gitmojiCli.ask('hook'),
+	version: () => console.log(gitmojiCli.version(pkg.version)),
+	commit: () => gitmojiCli.ask('client')
+};
 
-if (cli.flags.search) {
-	cli.input.map(element => {
-		return gitmojiCli.search(element);
-	});
-}
-
-if (cli.flags.commit) {
-	gitmojiCli.ask('client');
-}
-
-if (cli.flags.init) {
-	gitmojiCli.init();
-}
-
-if (cli.flags.hook) {
-	gitmojiCli.ask('hook');
-}
-
-if (cli.flags.version) {
-	console.log(gitmojiCli.version(pkg.version));
+const arg = Object.keys(cli.flags)[1];
+if (arg) {
+	commands[arg]();
 }

--- a/cli.js
+++ b/cli.js
@@ -47,10 +47,13 @@ const commands = {
 	init: () => gitmojiCli.init(),
 	hook: () => gitmojiCli.ask('hook'),
 	version: () => console.log(gitmojiCli.version(pkg.version)),
-	commit: () => gitmojiCli.ask('client')
+	commit: () => gitmojiCli.ask('client'),
+	undefined: () => gitmojiCli.ask('client')
 };
 
 const arg = Object.keys(cli.flags)[1];
-if (arg) {
+if (commands[arg]) {
 	commands[arg]();
+} else {
+	cli.showHelp();
 }


### PR DESCRIPTION
## Description

I have refactored the code to replace multiple "if" by an Object with arrow function.
When we run the cli without args, it will run the commit command.
If args are invalid, the help will be displayed.

<!-- Add issue number that this pull request refers to -->
Issue: #11 

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
