### PR TITLE
🐛  Fix access mode of prepare-commit-msg

### DIFF
--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -19,7 +19,7 @@ class GitmojiCli {
 		const fileContents = `#!/bin/sh\n# gitmoji as a commit hook\nexec < /dev/tty\ngitmoji --hook $1`;
 
 		if (this._isAGitRepo('.git')) {
-			fs.writeFile(path, fileContents, {mode: 755}, err => {
+			fs.writeFile(path, fileContents, {mode: 0o775}, err => {
 				if (err) {
 					console.error(chalk.red(`ERROR: ${err}`));
 				}


### PR DESCRIPTION
It seems that with fs.writeFile, the mode option needs to be specified as an octal number. I determined this after running `gitmoji -i`, and having the file created with very strange permissions:

```
$ stat .git/hooks/prepare-commit-msg
  File: '.git/hooks/prepare-commit-msg'
  Size: 70        	Blocks: 8          IO Block: 4096   regular file
Device: fd03h/64771d	Inode: 19398811    Links: 1
Access: (1361/--wxrw---t)  Uid: ( 1000/  grdryn)   Gid: ( 1000/  grdryn)
Context: unconfined_u:object_r:container_file_t:s0
Access: 2016-11-26 02:19:14.661093296 +0000
Modify: 2016-11-26 02:19:14.661093296 +0000
Change: 2016-11-26 02:19:14.661093296 +0000
 Birth: -
```

The docs[1] for this function give the default example as being in octal, and when I changed it and tried it out, it worked much better.

In addition, the rest of the files in `.git/hooks/` appear to have mode `775` rather than `755`, so I changed this here to match that also.

[1] https://nodejs.org/dist/latest-v7.x/docs/api/fs.html#fs_fs_writefile_file_data_options_callback