### PR TITLE
Adds an offline capability

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,7 @@ const cli = meow(`
 		--list, -l  List all the available gitmojis
 		--search, -s	Search gitmojis
 		--version, -v	Print gitmoji-cli installed version
+		--update, -u	Sync emoji list with the repo
 	Examples
 		$ gitmoji -l
 		$ gitmoji bug linter -s
@@ -28,7 +29,8 @@ const cli = meow(`
 		l: 'list',
 		s: 'search',
 		h: 'help',
-		v: 'version'
+		v: 'version',
+		u: 'update'
 	}
 });
 
@@ -48,6 +50,7 @@ const commands = {
 	hook: () => gitmojiCli.ask('hook'),
 	version: () => console.log(gitmojiCli.version(pkg.version)),
 	commit: () => gitmojiCli.ask('client'),
+	update: () => gitmojiCli.updateCache(),
 	undefined: () => {
 		if (process.argv[2] === '--hook') {
 			gitmojiCli.ask('hook');

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const chalk = require('chalk');
 const inquirer = require('inquirer');
 const execa = require('execa');
@@ -38,19 +39,13 @@ class GitmojiCli {
 	}
 
 	list() {
-		return this._gitmojiApiClient.request({
-			method: 'GET',
-			url: '/src/data/gitmojis.json'
-		}).then(res => res.data.gitmojis)
+		return this._fetchEmojis()
 			.then(gitmojis => this._parseGitmojis(gitmojis))
 			.catch(err => console.error(chalk.red(`ERROR: gitmoji list not found - ${err.code}`)));
 	}
 
 	search(name) {
-		return this._gitmojiApiClient.request({
-			method: 'GET',
-			url: '/src/data/gitmojis.json'
-		}).then(res => res.data.gitmojis)
+		return this._fetchEmojis()
 			.then(gitmojis => gitmojis.filter(gitmoji => gitmoji.name.concat(gitmoji.description).toLowerCase().indexOf(name.toLowerCase()) !== -1))
 			.then(gitmojisFiltered => this._parseGitmojis(gitmojisFiltered))
 		.catch(err => console.error(chalk.red(`ERROR: ${err.code}`)));
@@ -58,10 +53,7 @@ class GitmojiCli {
 
 	ask(mode) {
 		if (this._isAGitRepo('.git')) {
-			return this._gitmojiApiClient.request({
-				method: 'GET',
-				url: '/src/data/gitmojis.json'
-			}).then(res => res.data.gitmojis)
+			return this._fetchEmojis()
 				.then(gitmojis => this._questions(gitmojis))
 				.then(questions => {
 					inquirer.prompt(questions).then(answers => {
@@ -79,6 +71,11 @@ class GitmojiCli {
 			.catch(err => console.error(chalk.red(`ERROR: ${err.code}`)));
 		}
 		console.error(chalk.red('ERROR: This directory is not a git repository.'));
+	}
+
+	updateCache() {
+		this._fetchRemoteEmojis()
+			.then(emojis => this._createCache(this._getCachePath(), emojis));
 	}
 
 	_hook(answers) {
@@ -180,6 +177,47 @@ class GitmojiCli {
 
 	_isAGitRepo(dir) {
 		return pathExists.sync(dir);
+	}
+
+	_getCachePath() {
+		const home = process.env.HOME || process.env.USERPROFILE;
+		return path.join(home, '.gitmoji', 'gitmojis.json');
+	}
+
+	_isCacheExist(cachePath) {
+		return pathExists.sync(cachePath);
+	}
+
+	_createCache(cachePath, emojis) {
+		const cacheDir = path.dirname(cachePath);
+		if (!pathExists.sync(cacheDir)) {
+			fs.mkdirSync(cacheDir)
+		}
+		fs.writeFileSync(cachePath, JSON.stringify(emojis));
+	}
+
+	_fetchRemoteEmojis() {
+		return this._gitmojiApiClient.request({
+			method: 'GET',
+			url: '/src/data/gitmojis.json'
+		}).then(res => res.data.gitmojis)
+	}
+
+	_fetchCachedEmojis(cachePath) {
+		return Promise.resolve(JSON.parse(fs.readFileSync(cachePath)));
+	}
+
+	_fetchEmojis() {
+		const cachePath = this._getCachePath();
+		if (this._isCacheExist(cachePath)) {
+			return this._fetchCachedEmojis(cachePath);
+		} else {
+			return this._fetchRemoteEmojis()
+				.then(emojis => {
+					this._createCache(cachePath, emojis);
+					return emojis;
+				});
+		}
 	}
 }
 

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -65,6 +65,10 @@ class GitmojiCli {
 							case 'hook':
 								this._hook(answers);
 								break;
+							default:
+								console.error(chalk.red(
+									`ERROR: unexpected mode [${mode}]`
+								));
 						}
 					});
 				})
@@ -158,7 +162,7 @@ class GitmojiCli {
 	}
 
 	_parseGitmojis(gitmojis) {
-		return gitmojis.map(gitmoji => {
+		return gitmojis.forEach(gitmoji => {
 			console.log(`${gitmoji.emoji}  - ${chalk.blue(gitmoji.code)} - ${gitmoji.description}`);
 		});
 	}
@@ -191,7 +195,7 @@ class GitmojiCli {
 	_createCache(cachePath, emojis) {
 		const cacheDir = path.dirname(cachePath);
 		if (!pathExists.sync(cacheDir)) {
-			fs.mkdirSync(cacheDir)
+			fs.mkdirSync(cacheDir);
 		}
 		fs.writeFileSync(cachePath, JSON.stringify(emojis));
 	}
@@ -200,7 +204,7 @@ class GitmojiCli {
 		return this._gitmojiApiClient.request({
 			method: 'GET',
 			url: '/src/data/gitmojis.json'
-		}).then(res => res.data.gitmojis)
+		}).then(res => res.data.gitmojis);
 	}
 
 	_fetchCachedEmojis(cachePath) {
@@ -211,13 +215,12 @@ class GitmojiCli {
 		const cachePath = this._getCachePath();
 		if (this._isCacheExist(cachePath)) {
 			return this._fetchCachedEmojis(cachePath);
-		} else {
-			return this._fetchRemoteEmojis()
-				.then(emojis => {
-					this._createCache(cachePath, emojis);
-					return emojis;
-				});
 		}
+		return this._fetchRemoteEmojis()
+			.then(emojis => {
+				this._createCache(cachePath, emojis);
+				return emojis;
+			});
 	}
 }
 


### PR DESCRIPTION
## Description
Gitmoji caches a remote request to emoji list in `HOME/.gitmoji/gitmojis.json`. You can sync with Gitmoji repository manually by `gitmoji -u` command.
Issue: #1

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
