### PR TITLE
:sparkles: add commitizen prompter

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,9 +2,9 @@
 'use strict';
 
 const meow = require('meow');
-const axios = require('axios');
 const updateNotifier = require('update-notifier');
-const GitmojiCli = require('./src/gitmoji.js');
+const GitmojiCli = require('./src/gitmoji');
+const gitmojiApiClient = require('./src/api-client');
 const pkg = require('./package.json');
 
 updateNotifier({pkg}).notify();
@@ -34,14 +34,8 @@ const cli = meow(`
 	}
 });
 
-const gitmojiApiClient = axios.create({
-	baseURL: 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master',
-	timeout: 5000,
-	headers: {},
-	params: {}
-});
-
-const gitmojiCli = new GitmojiCli(gitmojiApiClient);
+const apiClient = gitmojiApiClient('https://raw.githubusercontent.com/carloscuesta/gitmoji/master');
+const gitmojiCli = new GitmojiCli(apiClient);
 
 const commands = {
 	list: () => gitmojiCli.list(),

--- a/commitizen.js
+++ b/commitizen.js
@@ -1,0 +1,25 @@
+const GitmojiCli = require('./src/gitmoji');
+const gitmojiApiClient = require('./src/api-client');
+
+function czEngine() {
+	const apiClient = gitmojiApiClient('https://raw.githubusercontent.com/carloscuesta/gitmoji/master');
+	const gitmojiCli = new GitmojiCli(apiClient);
+
+	return {
+		prompter(cz, commit) {
+			gitmojiCli._fetchEmojis().then(gitmojis => {
+				const questions = gitmojiCli._questions(gitmojis);
+				return cz.prompt(questions);
+			})
+			.then(answers => {
+				const commitTitle = gitmojiCli._commitTitle(answers);
+				const commitBody = gitmojiCli._commitBody(answers);
+				const args = gitmojiCli._isCommitSigned(answers.signed);
+
+				commit(`${commitTitle}\n${commitBody}`, {args});
+			});
+		}
+	};
+}
+
+module.exports = czEngine();

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gitmoji-cli",
   "version": "1.3.0",
   "description": "A gitmoji client for using emojis on commit messages.",
+  "main": "./commitizen.js",
   "engines": {
     "node": ">=4"
   },

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -1,0 +1,12 @@
+const axios = require('axios');
+
+module.exports = gitmojiApiClient;
+
+function gitmojiApiClient(baseURL) {
+	return axios.create({
+		baseURL,
+		timeout: 5000,
+		headers: {},
+		params: {}
+	});
+}

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -89,11 +89,19 @@ class GitmojiCli {
 		fs.writeFileSync(process.argv[3], `${commitTitle}\n${commitBody}`);
 	}
 
-	_commit(answers) {
-		const commitTitle = `${answers.gitmoji} ${answers.title}`;
+	_commitTitle(answers) {
+		return `${answers.gitmoji} ${answers.title}`;
+	}
+
+	_commitBody(answers) {
 		const reference = (answers.reference) ? `#${answers.reference}` : '';
+		return `${answers.message} ${reference}`;
+	}
+
+	_commit(answers) {
+		const commitTitle = this._commitTitle(answers);
+		const commitBody = this._commitBody(answers);
 		const signed = this._isCommitSigned(answers.signed);
-		const commitBody = `${answers.message} ${reference}`;
 
 		if (this._isAGitRepo('.git')) {
 			execa.stdout('git', ['add', '.'])


### PR DESCRIPTION
## Description

Adds a commitizen adapter as requested in #18.
To achieve this I moved the axios API client to an own file & pulled the message string generation out of the function that really commits.

Tests are still running, but there are none for commitizen prompters.
Currently working on a stub/mock, so that we can use some sort of integration tests, where we expect a set of questions and return a then function that gets predefined answers passed in. Then we can assert the value of the `commit` callback. Probably smth like [here](https://github.com/commitizen/cz-jira-smart-commit/blob/master/index.test.js)
Just wanted to share the work beforehand 🙂 

Issue: #18 

## Tests

- [x] All tests passed.