### PR TITLE
Report stdout as error if stderr is empty

### DIFF
--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -129,7 +129,7 @@ class GitmojiCli {
 			}
 			execa.shell(commit)
 				.then(res => console.log(chalk.blue(res.stdout)))
-				.catch(err => this._errorMessage(err.stderr));
+				.catch(err => this._errorMessage(err.stderr ? err.stderr : err.stdout));
 		}
 
 		return commit;


### PR DESCRIPTION
## Description

If auto add is disabled, the user will receive an empty error message when trying to commit unstaged changes. Although auto add is enabled by default now, there are cases where it will be disabled and then a user will receive an empty `ERROR:` message.

Issue: https://github.com/carloscuesta/gitmoji-cli/issues/39

**Previous behavior**

```sh
❯ ./cli.js
? Choose a gitmoji: 🎨  - Improving structure / format of the code.
? Enter the commit title: 123
? Enter the commit message: 123
? Issue / PR reference #:
? Signed commit: Yes
ERROR:
```

**New behavior**

```sh
❯ ./cli.js
? Choose a gitmoji: 🎨  - Improving structure / format of the code.
? Enter the commit title: foo
? Enter the commit message: bar
? Issue / PR reference #:
? Signed commit: Yes
ERROR: On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
	modified:   src/gitmoji.js

Untracked files:
	foo

no changes added to commit
```

## Tests

- [x] All tests passed.
