### PR TITLE
Add jira reference support

### DIFF
--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -45,7 +45,7 @@ class GitmojiCli {
 				if (err) {
 					this._errorMessage(err);
 				}
-				console.log(`${chalk.yellow('gitmoji')} commit hook created succesfully.`);
+				console.log(`${chalk.yellow('gitmoji')} commit hook created successfully.`);
 			});
 		}
 
@@ -239,7 +239,7 @@ class GitmojiCli {
 			method: 'GET',
 			url: '/src/data/gitmojis.json'
 		}).then(res => {
-			console.log(`${chalk.yellow('Gitmojis')} updated succesfully!`);
+			console.log(`${chalk.yellow('Gitmojis')} updated successfully!`);
 			return res.data.gitmojis;
 		})
 		.catch(err => this._errorMessage(`Network connection not found - ${err.code}`));

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -19,6 +19,9 @@ class GitmojiCli {
 		if (config.get('autoadd') === undefined) {
 			config.set('autoadd', true);
 		}
+		if (config.get('issueFormat') === undefined) {
+			config.set('issueFormat', 'github');
+		}
 	}
 
 	config() {
@@ -27,11 +30,18 @@ class GitmojiCli {
 				name: 'add',
 				message: 'Enable automatic "git add ."',
 				type: 'confirm'
+			},
+			{
+				name: 'issueFormat',
+				message: 'Choose Issue Format',
+				type: 'list',
+				choices: ['github', 'jira']
 			}
 		];
 
 		inquirer.prompt(questions).then(answers => {
 			config.set('autoadd', answers.add);
+			config.set('issueFormat', answers.issueFormat);
 		});
 	}
 
@@ -116,7 +126,8 @@ class GitmojiCli {
 
 	_commit(answers) {
 		const title = `${answers.gitmoji} ${answers.title}`;
-		const reference = (answers.reference) ? `#${answers.reference}` : '';
+		const prefixReference = config.get('issueFormat') === 'github' ? '#' : '';
+		const reference = (answers.reference) ? `${prefixReference}${answers.reference}` : '';
 		const signed = this._isCommitSigned(answers.signed);
 		const body = `${answers.message} ${reference}`;
 		const commit = `git commit ${signed} -m "${title}" -m "${body}"`;
@@ -168,17 +179,28 @@ class GitmojiCli {
 			},
 			{
 				name: 'reference',
-				message: 'Issue / PR reference #:',
+				message: 'Issue / PR reference:',
 				validate(value) {
 					if (value === '') {
 						return true;
 					}
 					if (value !== null) {
-						const validReference = value.match(/(^[1-9][0-9]*)+$/);
+						let validReference = '';
+						let errorReference = '';
+						switch (config.get('issueFormat')) {
+							case 'jira':
+								validReference = value.match(/^([A-Z][A-Z0-9]{1,9}-[0-9]+)$/g);
+								errorReference = 'Enter the JIRA reference key, such as ABC-123';
+								break;
+							default:
+								validReference = value.match(/(^[1-9][0-9]*)+$/);
+								errorReference = 'Enter the number of the reference without the #. Eg: 12';
+						}
+
 						if (validReference) {
 							return true;
 						}
-						return chalk.red('Enter the number of the reference without the #. Eg: 12');
+						return chalk.red(errorReference);
 					}
 				}
 			},

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,9 @@ const axios = require('axios');
 const GitmojiCli = require('./../src/gitmoji.js');
 const should = require('should');
 const pkg = require('./../package.json');
+const Conf = require('conf');
+
+const config = new Conf();
 
 const gitmojiApiClient = axios.create({
 	baseURL: 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master',
@@ -21,14 +24,30 @@ const prompts = {
 	signed: true
 };
 
+const promptsForJiraCommit = {
+	gitmoji: ':zap:',
+	title: 'Improving performance issues.',
+	message: 'Refactored code.',
+	reference: 'ABC-123',
+	signed: true
+};
+
 const gitmojiCli = new GitmojiCli(gitmojiApiClient);
 
 
 describe('gitmoji', function() {
 
-	describe('commit', function() {
+	describe('commit-with-github-format', function() {
 		it('should return the formed commit based on the input prompts', function() {
+			config.set('issueFormat', 'github');
 			gitmojiCli._commit(prompts).should.equal('git commit -S -m ":zap: Improving performance issues." -m "Refactored code. #5"');
+		});
+	});
+
+	describe('commit-with-jira-format', function() {
+		it('should return the formed commit based on the input prompts', function() {
+			config.set('issueFormat', 'jira');
+			gitmojiCli._commit(promptsForJiraCommit).should.equal('git commit -S -m ":zap: Improving performance issues." -m "Refactored code. ABC-123"');
 		});
 	});
 


### PR DESCRIPTION
## Description
This pull request adds the ability to:
 - Set a issue tracker format in the settings (defaults to github)
 - Validate JIRA issue keys if issue tracker format is set to JIRA
 - Remove the preceeding # if issue tracker format is set to JIRA

Go easy on me, it is my first attempt at node. I was thinking about a larger refactoring where the issue tracker is an object that encapsulates it's own rules and formatting, so like
```
class JIRAFormatter {
    function getPrefix() {};
    function isValid() {};
    function getCommitTemplate() { // {issuekey} {summary} - {description} }
} 

class GithubFormatter {
    function getPrefix() {};
    function isValid() {}
    function getCommitTemplate() { // {summary} - {description} {issuekey} }
}
```
... but I decided against it for the time being! Maybe another day.

All feedback welcome. :)

Issue: #44 

## Tests

Not sure how to run the tests - help welcome!
