### PR TITLE
:sparkles: Add emoji format to config

### DIFF
--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -36,12 +36,22 @@ class GitmojiCli {
 				message: 'Choose Issue Format',
 				type: 'list',
 				choices: ['github', 'jira']
+			},
+			{
+				name: 'emojiFormat',
+				message: 'Select how emojis should be used in commits',
+				type: 'list',
+				choices: [
+          {name: ':smile:', value: 'code'},
+          {name: '😄', value: 'emoji'}
+				]
 			}
 		];
 
 		inquirer.prompt(questions).then(answers => {
 			config.set('autoadd', answers.add);
 			config.set('issueFormat', answers.issueFormat);
+			config.set('emojiFormat', answers.emojiFormat);
 		});
 	}
 
@@ -158,7 +168,7 @@ class GitmojiCli {
 						.map(gitmoji => {
 							return {
 								name: `${gitmoji.emoji}  - ${gitmoji.description}`,
-								value: gitmoji.code
+								value: gitmoji[config.get('emojiFormat') || 'code']
 							};
 						}));
 				}

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -22,6 +22,9 @@ class GitmojiCli {
 		if (config.get('issueFormat') === undefined) {
 			config.set('issueFormat', 'github');
 		}
+		if (config.get('emojiFormat') === undefined) {
+			config.set('emojiFormat', 'code');
+		}
 	}
 
 	config() {
@@ -41,10 +44,7 @@ class GitmojiCli {
 				name: 'emojiFormat',
 				message: 'Select how emojis should be used in commits',
 				type: 'list',
-				choices: [
-          {name: ':smile:', value: 'code'},
-          {name: '😄', value: 'emoji'}
-				]
+				choices: [{name: ':smile:', value: 'code'}, {name: '😄', value: 'emoji'}]
 			}
 		];
 

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,39 @@ const gitmojiCli = new GitmojiCli(gitmojiApiClient);
 
 describe('gitmoji', function() {
 
+  describe('commit-with-text-emoji', function() {
+    it('should use the unicode emoji', function() {
+      config.set('emojiFormat', 'code');
+      const gitmojis = [
+        { emoji: '⚡️', code: ':zap:', description: '', name: 'zap' }
+      ]
+      const emojiQuestion = gitmojiCli._questions(gitmojis)[0]
+      return emojiQuestion.source(null, 'zap').then(function (emojis) {
+        emojis[0].value.should.equal(':zap:')
+      })
+    });
+  });
+
+  describe('commit-with-unicode-emoji', function() {
+    it('should use the unicode emoji', function() {
+      config.set('emojiFormat', 'emoji');
+      const gitmojis = [
+        { emoji: '⚡️', code: ':zap:', description: '', name: 'zap' }
+      ]
+      const emojiQuestion = gitmojiCli._questions(gitmojis)[0]
+      return emojiQuestion.source(null, 'zap').then(function (emojis) {
+        emojis[0].value.should.equal('⚡️')
+      })
+    });
+  });
+
+  describe('commit-with-jira-format', function() {
+    it('should return the formed commit based on the input prompts', function() {
+      config.set('issueFormat', 'jira');
+      gitmojiCli._commit(promptsForJiraCommit).should.equal('git commit -S -m ":zap: Improving performance issues." -m "Refactored code. ABC-123"');
+    });
+  });
+
 	describe('commit-with-github-format', function() {
 		it('should return the formed commit based on the input prompts', function() {
 			config.set('issueFormat', 'github');


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
I added back this feature I asked for along with the test case. I kept the `:smile:` format as the first option and also as the fallback case
<!-- Add issue number that this pull request refers to -->
Issue: #

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
