### PR TITLE
✨ Add possibility to remove hook

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -14,6 +14,7 @@ const cli = meow(`
 	  $ gitmoji
 	Options
 		--init, -i	Initialize gitmoji as a commit hook
+		--remove -r Remove a previously initialized commit hook
 		--config, -g Setup gitmoji-cli preferences.
 		--commit, -c Interactively commit using the prompts
 		--list, -l  List all the available gitmojis
@@ -26,6 +27,7 @@ const cli = meow(`
 `, {
 	alias: {
 		i: 'init',
+		r: 'remove',
 		c: 'commit',
 		l: 'list',
 		s: 'search',
@@ -50,6 +52,7 @@ const commands = {
 	config: () => gitmojiCli.config(),
 	search: () => cli.input.map(element => gitmojiCli.search(element)),
 	init: () => gitmojiCli.init(),
+	remove: () => gitmojiCli.remove(),
 	hook: () => gitmojiCli.ask('hook'),
 	version: () => console.log(gitmojiCli.version(pkg.version)),
 	commit: () => gitmojiCli.ask('client'),

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -74,11 +74,11 @@ class GitmojiCli {
 			fileContents
 		};
 	}
-	
-	unhook() {
+
+	remove() {
 		const hookFile = 'prepare-commit-msg';
 		const path = `${process.env.PWD}/.git/hooks/${hookFile}`;
-		
+
 		if (this._isAGitRepo('.git')) {
 			fs.unlink(path, err => {
 				if (err) {

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -11,6 +11,8 @@ inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'))
 
 const config = new Conf();
 
+const commitHookPath = `${process.env.PWD}/.git/hooks/prepare-commit-msg`;
+
 class GitmojiCli {
 
 	constructor(gitmojiApiClient, gitmojis) {
@@ -56,12 +58,10 @@ class GitmojiCli {
 	}
 
 	init() {
-		const hookFile = 'prepare-commit-msg';
-		const path = `${process.env.PWD}/.git/hooks/${hookFile}`;
 		const fileContents = `#!/bin/sh\n# gitmoji as a commit hook\nexec < /dev/tty\ngitmoji --hook $1`;
 
 		if (this._isAGitRepo('.git')) {
-			fs.writeFile(path, fileContents, {mode: 0o775}, err => {
+			fs.writeFile(commitHookPath, fileContents, {mode: 0o775}, err => {
 				if (err) {
 					this._errorMessage(err);
 				}
@@ -70,17 +70,14 @@ class GitmojiCli {
 		}
 
 		return {
-			path,
+			commitHookPath,
 			fileContents
 		};
 	}
 
 	remove() {
-		const hookFile = 'prepare-commit-msg';
-		const path = `${process.env.PWD}/.git/hooks/${hookFile}`;
-
 		if (this._isAGitRepo('.git')) {
-			fs.unlink(path, err => {
+			fs.unlink(commitHookPath, err => {
 				if (err) {
 					this._errorMessage(err);
 				}
@@ -89,7 +86,7 @@ class GitmojiCli {
 		}
 
 		return {
-			path
+			commitHookPath
 		};
 	}
 

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -74,6 +74,24 @@ class GitmojiCli {
 			fileContents
 		};
 	}
+	
+	unhook() {
+		const hookFile = 'prepare-commit-msg';
+		const path = `${process.env.PWD}/.git/hooks/${hookFile}`;
+		
+		if (this._isAGitRepo('.git')) {
+			fs.unlink(path, err => {
+				if (err) {
+					this._errorMessage(err);
+				}
+				console.log(`${chalk.yellow('gitmoji')} commit hook unlinked successfully.`);
+			});
+		}
+
+		return {
+			path
+		};
+	}
 
 	version(number) {
 		return number;

--- a/test/test.js
+++ b/test/test.js
@@ -86,11 +86,17 @@ describe('gitmoji', function() {
 
 	describe('init', function() {
 		it('path should be set to .git/hooks/prepare-commit-msg', function() {
-			gitmojiCli.init().path.should.containEql('.git/hooks/prepare-commit-msg');
+			gitmojiCli.init().commitHookPath.should.containEql('.git/hooks/prepare-commit-msg');
 		});
 
 		it('prepare-commit-msg should contain the hook script', function() {
 			gitmojiCli.init().fileContents.should.containEql('exec < /dev/tty\ngitmoji --hook $1');
+		});
+	});
+
+	describe('remove', function() {
+		it('path should be set to .git/hooks/prepare-commit-msg', function() {
+			gitmojiCli.remove().commitHookPath.should.containEql('.git/hooks/prepare-commit-msg');
 		});
 	});
 


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
Introduces the new command `--remove|-r` to unlink a previously set hook. Avoids having to dive into the .git dir in a terminal and remove it there. I love Gitmoji, but sometimes needed to remove it for projects where other people didn't want to use it.

It uses `fs#unlink` which is an async method that takes the path and a completion callback. Very much like `fs#writeFile`.

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
