### PR TITLE
🐛 Use fs.writeFile and exit the process if success @ hook

### DIFF
--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -111,7 +111,14 @@ class GitmojiCli {
     const title = `${answers.gitmoji} ${answers.title}`
     const reference = (answers.reference) ? `#${answers.reference}` : ''
     const body = `${answers.message} ${reference}`
-    fs.writeFileSync(process.argv[3], `${title}\n\n${body}`)
+
+    fs.writeFile(process.argv[3], `${title}\n\n${body}`, (error) => {
+      if (error) {
+        return this._errorMessage(error)
+      }
+
+      process.exit(0)
+    })
   }
 
   _commit (answers) {


### PR DESCRIPTION
## Description

Use `fs.writeFile` and `process.exit()` at `_hook` method. This will prevent to freeze when using the hook option.

## Tests

- [x] All tests passed.
