### PR TITLE
🐛 Fix gitmoji -i error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 *.log
 node_modules/
 coverage/

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ const GITHUB = 'github'
 const HOOK_MODE = 'hook'
 const HOOK_FILE_CONTENTS = '#!/bin/sh\n# gitmoji as a commit hook\n' +
   'exec < /dev/tty\ngitmoji --hook $1'
+const HOOK_DIR = '/.git/hooks'
 const HOOK_PATH = '/.git/hooks/prepare-commit-msg'
 const HOOK_PERMISSIONS = 0o775
 const ISSUE_FORMAT = 'issueFormat'
@@ -18,6 +19,7 @@ module.exports = {
   GITHUB,
   HOOK_MODE,
   HOOK_FILE_CONTENTS,
+  HOOK_DIR,
   HOOK_PATH,
   HOOK_PERMISSIONS,
   ISSUE_FORMAT,

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -37,7 +37,11 @@ class GitmojiCli {
     if (!this._isAGitRepo()) {
       return this._errorMessage('Not a git repository - @init')
     }
-
+    try {
+      fs.accessSync(process.cwd() + constants.HOOK_DIR)
+    } catch (e) {
+      fs.mkdirSync(process.cwd() + constants.HOOK_DIR)
+    }
     fs.writeFile(
       process.cwd() + constants.HOOK_PATH, constants.HOOK_FILE_CONTENTS,
       { mode: constants.HOOK_PERMISSIONS },

--- a/test/__snapshots__/gitmojiCli.spec.js.snap
+++ b/test/__snapshots__/gitmojiCli.spec.js.snap
@@ -27,6 +27,7 @@ Object {
   "CODE": "code",
   "EMOJI_FORMAT": "emojiFormat",
   "GITHUB": "github",
+  "HOOK_DIR": "/.git/hooks",
   "HOOK_FILE_CONTENTS": "#!/bin/sh
 # gitmoji as a commit hook
 exec < /dev/tty


### PR DESCRIPTION
## Description

when run `gitmoji -i`, I may got `ERROR: Error: ENOENT: no such file or directory, open 'xxxxxx/.git/hooks/prepare-commit-msg'`

it is caused because `/.git/hook` dir not exist, and this pr should solve this.

Issue: #81 

## Tests

- [ ] All tests passed.
