### PR TITLE
:sparkles: Add sign-off support

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const getAutoAdd = () => config.get(constants.AUTO_ADD)
 const getEmojiFormat = () => config.get(constants.EMOJI_FORMAT)
 const getIssueFormat = () => config.get(constants.ISSUE_FORMAT)
 const getSignedCommit = () => config.get(constants.SIGNED_COMMIT)
+const getSignedOffCommit = () => config.get(constants.SIGNED_OFF_COMMIT)
 const setAutoAdd = (autoAdd) => config.set(constants.AUTO_ADD, autoAdd)
 const setEmojiFormat = (emojiFormat) => {
   config.set(constants.EMOJI_FORMAT, emojiFormat)
@@ -17,14 +18,19 @@ const setIssueFormat = (issueFormat) => {
 const setSignedCommit = (signedCommit) => {
   config.set(constants.SIGNED_COMMIT, signedCommit)
 }
+const setSignedOffCommit = (signedOffCommit) => {
+  config.set(constants.SIGNED_OFF_COMMIT, signedOffCommit)
+}
 
 module.exports = {
   getAutoAdd,
   getEmojiFormat,
   getIssueFormat,
   getSignedCommit,
+  getSignedOffCommit,
   setAutoAdd,
   setEmojiFormat,
   setIssueFormat,
-  setSignedCommit
+  setSignedCommit,
+  setSignedOffCommit
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ const HOOK_PERMISSIONS = 0o775
 const ISSUE_FORMAT = 'issueFormat'
 const JIRA = 'jira'
 const SIGNED_COMMIT = 'signedCommit'
+const SIGNED_OFF_COMMIT = 'signedOffCommit'
 
 module.exports = {
   AUTO_ADD,
@@ -22,5 +23,6 @@ module.exports = {
   HOOK_PERMISSIONS,
   ISSUE_FORMAT,
   JIRA,
-  SIGNED_COMMIT
+  SIGNED_COMMIT,
+  SIGNED_OFF_COMMIT
 }

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -30,6 +30,7 @@ class GitmojiCli {
       config.setIssueFormat(answers[constants.ISSUE_FORMAT])
       config.setEmojiFormat(answers[constants.EMOJI_FORMAT])
       config.setSignedCommit(answers[constants.SIGNED_COMMIT])
+      config.setSignedOffCommit(answers[constants.SIGNED_OFF_COMMIT])
     })
   }
 
@@ -127,8 +128,9 @@ class GitmojiCli {
       ? `${prefixReference}${answers.reference}`
       : ''
     const signed = config.getSignedCommit() ? '-S' : ''
+    const signedOff = config.getSignedOffCommit() ? '-s' : ''
     const body = `${answers.message} ${reference}`
-    const commit = `git commit ${signed} -m "${title}" -m "${body}"`
+    const commit = `git commit ${signedOff} ${signed} -m "${title}" -m "${body}"`
 
     if (!this._isAGitRepo()) {
       return this._errorMessage('Not a git repository')

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -26,6 +26,12 @@ const config = [
     name: constants.SIGNED_COMMIT,
     message: 'Enable signed commits',
     type: 'confirm'
+  },
+  {
+    name: constants.SIGNED_OFF_COMMIT,
+    message: 'Enable signed-off commits',
+    type: 'confirm',
+    default: false
   }
 ]
 

--- a/test/__snapshots__/gitmojiCli.spec.js.snap
+++ b/test/__snapshots__/gitmojiCli.spec.js.snap
@@ -14,10 +14,12 @@ Object {
   "getEmojiFormat": [Function],
   "getIssueFormat": [Function],
   "getSignedCommit": [Function],
+  "getSignedOffCommit": [Function],
   "setAutoAdd": [Function],
   "setEmojiFormat": [Function],
   "setIssueFormat": [Function],
   "setSignedCommit": [Function],
+  "setSignedOffCommit": [Function],
 }
 `;
 
@@ -38,12 +40,13 @@ gitmoji --hook $1
   "ISSUE_FORMAT": "issueFormat",
   "JIRA": "jira",
   "SIGNED_COMMIT": "signedCommit",
+  "SIGNED_OFF_COMMIT": "signedOffCommit",
 }
 `;
 
-exports[`gitmoji module commit should match for the commit snapshot with the given prompts 1`] = `"git commit -S -m \\":zap: Improving performance issues.\\" -m \\"Refactored code. #5\\""`;
+exports[`gitmoji module commit should match for the commit snapshot with the given prompts 1`] = `"git commit  -S -m \\":zap: Improving performance issues.\\" -m \\"Refactored code. #5\\""`;
 
-exports[`gitmoji module commit should match for the commit snapshot with the given prompts 2`] = `"git commit  -m \\":zap: Improving performance issues.\\" -m \\"Refactored code. ABC-123\\""`;
+exports[`gitmoji module commit should match for the commit snapshot with the given prompts 2`] = `"git commit   -m \\":zap: Improving performance issues.\\" -m \\"Refactored code. ABC-123\\""`;
 
 exports[`gitmoji module should match for gitmoji class 1`] = `
 GitmojiCli {
@@ -102,6 +105,12 @@ Array [
   Object {
     "message": "Enable signed commits",
     "name": "signedCommit",
+    "type": "confirm",
+  },
+  Object {
+    "default": false,
+    "message": "Enable signed-off commits",
+    "name": "signedOffCommit",
     "type": "confirm",
   },
 ]


### PR DESCRIPTION
Introduce a config to add the Signed-off-by field (-s) while committing

Signed-off-by: LI JIAHAO <lijiahao99131@gmail.com>

## Description

<!-- Explanation about your pull request, what changes you've made -->
Adding the "Signed-off-by" field in commits might be useful in some project practice. Not enabled by default since most projects don't use it.
<!-- Add issue number that this pull request refers to -->
Issue: #

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests are passing within the default configuration.
