### PR TITLE
🐛 Fix race-condition in hook mode

### DIFF
--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -122,13 +122,12 @@ class GitmojiCli {
     const reference = (answers.reference) ? `#${answers.reference}` : ''
     const body = `${answers.message} ${reference}`
 
-    fs.writeFile(process.argv[3], `${title}\n\n${body}`, (error) => {
-      if (error) {
-        return this._errorMessage(error)
-      }
-
-      process.exit(0)
-    })
+    try {
+      fs.writeFileSync(process.argv[3], `${title}\n\n${body}`)
+    } catch (error) {
+      return this._errorMessage(error)
+    }
+    process.exit(0)
   }
 
   _commit (answers) {


### PR DESCRIPTION
## Description

When in hook mode, it can happen that we exit function and directly go to calling `_commit` BEFORE actually finishing `_hook` code.
This can be detected adding `console.log` statements to code and trying to commit different messages:

```
diff --git a/src/gitmoji.js b/src/gitmoji2.js
index 4e7809a..e9639a0 100644
--- a/src/gitmoji.js
+++ b/src/gitmoji2.js
@@ -127,11 +127,13 @@ class GitmojiCli {
         return this._errorMessage(error)
       }

+      console.log('_hook exited');
       process.exit(0)
     })
   }

   _commit (answers) {
+    console.log('_commit called');
     const title = `${answers.gitmoji} ${answers.title}`
     const prefixReference = config.getIssueFormat() === constants.GITHUB
       ? '#'
```

And here is the output of running modified gitmoji hook in the repo (commit was aborted intentionally):

```
➜ git commit -aS
? Choose a gitmoji: 🚨  - Removing linter warnings.
? Enter the commit title [3/48]: asd
? Enter the commit message: dsa
? Issue / PR reference: BO-33
_commit called
_hook exited
Aborting commit due to empty commit message.
```

The problem happens because we call `_commit` without waiting for `_hook` to finish writing to `.git/EDIT_COMMITMSG`. Using synchronous write to file fixes the issue, as we don't rely on assumption that _it should finish writing BEFORE we exit the function_, but have a guarantee for that.

## Tests

- [x] All tests passed.
