### PR TITLE
Add auto on empty stage option

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "meow": "^5.0.0",
     "parent-dirs": "^1.0.0",
     "path-exists": "^3.0.0",
+    "staged-git-files": "^1.1.1",
     "update-notifier": "^2.3.0"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,7 @@ const getEmojiFormat = () => config.get(constants.EMOJI_FORMAT)
 const getIssueFormat = () => config.get(constants.ISSUE_FORMAT)
 const getSignedCommit = () => config.get(constants.SIGNED_COMMIT)
 const setAutoAdd = (autoAdd) => config.set(constants.AUTO_ADD, autoAdd)
+const setAutoAddOnEmptyStage = (setAutoAddOnEmptyStage) => config.set(constants.AUTO_ADD_ON_EMPTY_STAGE, setAutoAddOnEmptyStage)
 const setEmojiFormat = (emojiFormat) => {
   config.set(constants.EMOJI_FORMAT, emojiFormat)
 }
@@ -26,6 +27,7 @@ module.exports = {
   getIssueFormat,
   getSignedCommit,
   setAutoAdd,
+  setAutoAddOnEmptyStage,
   setEmojiFormat,
   setIssueFormat,
   setSignedCommit

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const constants = require('./constants')
 const config = new Conf()
 
 const getAutoAdd = () => config.get(constants.AUTO_ADD)
+const getAutoAddOnEmptyStage = () => config.get(constants.AUTO_ADD_ON_EMPTY_STAGE)
 const getEmojiFormat = () => config.get(constants.EMOJI_FORMAT)
 const getIssueFormat = () => config.get(constants.ISSUE_FORMAT)
 const getSignedCommit = () => config.get(constants.SIGNED_COMMIT)
@@ -20,6 +21,7 @@ const setSignedCommit = (signedCommit) => {
 
 module.exports = {
   getAutoAdd,
+  getAutoAddOnEmptyStage,
   getEmojiFormat,
   getIssueFormat,
   getSignedCommit,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 const AUTO_ADD = 'autoAdd'
+const AUTO_ADD_ON_EMPTY_STAGE = 'autoAddOnEmptyStage'
 const CODE = 'code'
 const EMOJI_FORMAT = 'emojiFormat'
 const GITHUB = 'github'
@@ -14,6 +15,7 @@ const TITLE_MAX_LENGTH_COUNT = 48
 
 module.exports = {
   AUTO_ADD,
+  AUTO_ADD_ON_EMPTY_STAGE,
   CODE,
   EMOJI_FORMAT,
   GITHUB,

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -144,7 +144,7 @@ class GitmojiCli {
     const signed = config.getSignedCommit() ? '-S' : ''
     const body = `${answers.message} ${reference}`
     const commit = `git commit ${signed} -m "${title}" -m "${body}"`
-    const promises = []
+    const addPromises = []
 
     const getCommit = () => commit
     const gitCommit = () => execa.shellSync(commit)
@@ -168,13 +168,13 @@ class GitmojiCli {
     }
 
     if (config.getAutoAdd()) {
-      promises.push(gitAdd)
+      addPromises.push(gitAdd)
     } else if (config.getAutoAddOnEmptyStage()) {
-      promises.push(gitAddOnEmptyStage)
+      addPromises.push(gitAddOnEmptyStage)
     }
 
-    return promises
-      .concat(gitCommit, getCommit)
+    return []
+      .concat(addPromises, [ gitCommit, getCommit ])
       .reduce(
         (promise, func) => promise
           .then((res) => {

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -23,7 +23,7 @@ class GitmojiCli {
     this._gitmojiApiClient = gitmojiApiClient
     this._gitmojis = gitmojis
     if (config.getAutoAdd() === undefined) config.setAutoAdd(true)
-    if (config.getAutoAddOnEmptyStage() === undefined) config.getAutoAddOnEmptyStage(false)
+    if (config.getAutoAddOnEmptyStage() === undefined) config.setAutoAddOnEmptyStage(false)
     if (!config.getIssueFormat()) config.setIssueFormat(constants.GITHUB)
     if (!config.getEmojiFormat()) config.setEmojiFormat(constants.CODE)
     if (config.getSignedCommit() === undefined) config.setSignedCommit(true)
@@ -32,6 +32,7 @@ class GitmojiCli {
   config () {
     inquirer.prompt(prompts.config).then(answers => {
       config.setAutoAdd(answers[constants.AUTO_ADD])
+      config.setAutoAddOnEmptyStage(answers[constants.AUTO_ADD_ON_EMPTY_STAGE])
       config.setIssueFormat(answers[constants.ISSUE_FORMAT])
       config.setEmojiFormat(answers[constants.EMOJI_FORMAT])
       config.setSignedCommit(answers[constants.SIGNED_COMMIT])

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -146,9 +146,9 @@ class GitmojiCli {
     const commit = `git commit ${signed} -m "${title}" -m "${body}"`
     const addPromises = []
 
-    const getCommit = () => commit
-    const gitCommit = () => execa.shellSync(commit)
-    const gitAdd = () => execa.sync('git', ['add', '.'])
+    const getCommit = () => Promise.resolve(commit)
+    const gitCommit = () => execa.shell(commit)
+    const gitAdd = () => execa.stdout('git', ['add', '.'])
 
     const isStageEmpty = () => new Promise((resolve, reject) => {
       stagedGitFiles((err, stagedFiles) => {

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -11,7 +11,7 @@ const config = [
   },
   {
     name: constants.AUTO_ADD_ON_EMPTY_STAGE,
-    message: 'Enable automatic "git add ." if no file has been added',
+    message: 'Enable automatic "git add ." when there are no staged changes',
     type: 'confirm',
     when: (answers) => !answers[constants.AUTO_ADD]
   },

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -10,6 +10,12 @@ const config = [
     type: 'confirm'
   },
   {
+    name: constants.AUTO_ADD_ON_EMPTY_STAGE,
+    message: 'Enable automatic "git add ." if no file has been added',
+    type: 'confirm',
+    when: (answers) => !answers[constants.AUTO_ADD]
+  },
+  {
     name: constants.ISSUE_FORMAT,
     message: 'Choose Issue Format',
     type: 'list',

--- a/test/__snapshots__/gitmojiCli.spec.js.snap
+++ b/test/__snapshots__/gitmojiCli.spec.js.snap
@@ -2,6 +2,8 @@
 
 exports[`config module should match for setAutoAdd and getAutoAdd 1`] = `false`;
 
+exports[`config module should match for setAutoAddOnEmptyStage and getAutoAddOnEmptyStage 1`] = `true`;
+
 exports[`config module should match for setEmojiFormat and getEmojiFormat 1`] = `"code"`;
 
 exports[`config module should match for setIssueFormat and getIssueFormat 1`] = `"github"`;
@@ -11,10 +13,12 @@ exports[`config module should match for setSignedCommit and getSignedCommit 1`] 
 exports[`config module should match the exported methods 1`] = `
 Object {
   "getAutoAdd": [Function],
+  "getAutoAddOnEmptyStage": [Function],
   "getEmojiFormat": [Function],
   "getIssueFormat": [Function],
   "getSignedCommit": [Function],
   "setAutoAdd": [Function],
+  "setAutoAddOnEmptyStage": [Function],
   "setEmojiFormat": [Function],
   "setIssueFormat": [Function],
   "setSignedCommit": [Function],
@@ -24,6 +28,7 @@ Object {
 exports[`constants module should match for the exported constants 1`] = `
 Object {
   "AUTO_ADD": "autoAdd",
+  "AUTO_ADD_ON_EMPTY_STAGE": "autoAddOnEmptyStage",
   "CODE": "code",
   "EMOJI_FORMAT": "emojiFormat",
   "GITHUB": "github",
@@ -75,6 +80,12 @@ Array [
     "message": "Enable automatic \\"git add .\\"",
     "name": "autoAdd",
     "type": "confirm",
+  },
+  Object {
+    "message": "Enable automatic \\"git add .\\" if no file has been added",
+    "name": "autoAddOnEmptyStage",
+    "type": "confirm",
+    "when": [Function],
   },
   Object {
     "choices": Array [

--- a/test/__snapshots__/gitmojiCli.spec.js.snap
+++ b/test/__snapshots__/gitmojiCli.spec.js.snap
@@ -82,7 +82,7 @@ Array [
     "type": "confirm",
   },
   Object {
-    "message": "Enable automatic \\"git add .\\" if no file has been added",
+    "message": "Enable automatic \\"git add .\\" when there are no staged changes",
     "name": "autoAddOnEmptyStage",
     "type": "confirm",
     "when": [Function],

--- a/test/gitmojiCli.spec.js
+++ b/test/gitmojiCli.spec.js
@@ -79,7 +79,7 @@ describe('gitmoji module', () => {
   })
 
   describe('commit', () => {
-    it('should match for the commit snapshot with the given prompts', () => new Promise((resolve, reject) => {
+    it('should match for the commit snapshot with the given prompts', () => new Promise((resolve) => {
       config.setIssueFormat('github')
       config.setSignedCommit(true)
       gitmojiCli._commit(stubs.prompts).then((res) => {
@@ -88,7 +88,7 @@ describe('gitmoji module', () => {
       })
     }))
 
-    it('should match for the commit snapshot with the given prompts', () => new Promise((resolve, reject) => {
+    it('should match for the commit snapshot with the given prompts', () => new Promise((resolve) => {
       config.setIssueFormat('jira')
       config.setSignedCommit(false)
       gitmojiCli._commit(stubs.promptsJira).then((res) => {

--- a/test/gitmojiCli.spec.js
+++ b/test/gitmojiCli.spec.js
@@ -79,17 +79,23 @@ describe('gitmoji module', () => {
   })
 
   describe('commit', () => {
-    it('should match for the commit snapshot with the given prompts', async () => {
+    it('should match for the commit snapshot with the given prompts', () => new Promise((resolve, reject) => {
       config.setIssueFormat('github')
       config.setSignedCommit(true)
-      expect(await gitmojiCli._commit(stubs.prompts)).toMatchSnapshot()
-    })
+      gitmojiCli._commit(stubs.prompts).then((res) => {
+        expect(res).toMatchSnapshot()
+        resolve()
+      })
+    }))
 
-    it('should match for the commit snapshot with the given prompts', async () => {
+    it('should match for the commit snapshot with the given prompts', () => new Promise((resolve, reject) => {
       config.setIssueFormat('jira')
       config.setSignedCommit(false)
-      expect(await gitmojiCli._commit(stubs.promptsJira)).toMatchSnapshot()
-    })
+      gitmojiCli._commit(stubs.promptsJira).then((res) => {
+        expect(res).toMatchSnapshot()
+        resolve()
+      })
+    }))
   })
 
   describe('_isAGitRepo', () => {

--- a/test/gitmojiCli.spec.js
+++ b/test/gitmojiCli.spec.js
@@ -52,6 +52,11 @@ describe('config module', () => {
     expect(config.getAutoAdd()).toMatchSnapshot()
   })
 
+  it('should match for setAutoAddOnEmptyStage and getAutoAddOnEmptyStage', () => {
+    config.setAutoAddOnEmptyStage(true)
+    expect(config.getAutoAddOnEmptyStage()).toMatchSnapshot()
+  })
+
   it('should match for setEmojiFormat and getEmojiFormat', () => {
     config.setEmojiFormat('code')
     expect(config.getEmojiFormat()).toMatchSnapshot()
@@ -74,16 +79,16 @@ describe('gitmoji module', () => {
   })
 
   describe('commit', () => {
-    it('should match for the commit snapshot with the given prompts', () => {
+    it('should match for the commit snapshot with the given prompts', async () => {
       config.setIssueFormat('github')
       config.setSignedCommit(true)
-      expect(gitmojiCli._commit(stubs.prompts)).toMatchSnapshot()
+      expect(await gitmojiCli._commit(stubs.prompts)).toMatchSnapshot()
     })
 
-    it('should match for the commit snapshot with the given prompts', () => {
+    it('should match for the commit snapshot with the given prompts', async () => {
       config.setIssueFormat('jira')
       config.setSignedCommit(false)
-      expect(gitmojiCli._commit(stubs.promptsJira)).toMatchSnapshot()
+      expect(await gitmojiCli._commit(stubs.promptsJira)).toMatchSnapshot()
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3576,7 +3576,7 @@ stack-utils@^1.0.1:
 
 staged-git-files@^1.1.1:
   version "1.1.1"
-  resolved "https://npm.apps.dgadteamdev.com/repository/dgad/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
 
 standard-engine@~9.0.0:
   version "9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,6 +3574,10 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
+staged-git-files@^1.1.1:
+  version "1.1.1"
+  resolved "https://npm.apps.dgadteamdev.com/repository/dgad/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
+
 standard-engine@~9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-9.0.0.tgz#d3a3d74c4c1b91f51a1e66362465261ca7610316"


### PR DESCRIPTION
## Description

Add an option `autoAddOnEmptyStage` in the configuration, shown to the user if he has chosen no to `autoAdd` option.

If he selects `autoAddOnEmptyStage` option, `git add .` is run only if no file is staged.

---

Also wait for `git add .` execution to finish before commiting, possibly fixing #64 

Issue: #127 

## Tests

- [X] All tests passed.
