### PR TITLE
Support older git versions (< 2.13 - for debian stable/stretch)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,7 @@ const ISSUE_FORMAT = 'issueFormat'
 const JIRA = 'jira'
 const SIGNED_COMMIT = 'signedCommit'
 const TITLE_MAX_LENGTH_COUNT = 48
+const GIT_VERSION_PATTERN = /^(?:^|\s+)git version ([0-9]+)\.([0-9]+)\.([0-9]+)(?:\s+|$)/i
 
 module.exports = {
   AUTO_ADD,
@@ -24,5 +25,6 @@ module.exports = {
   ISSUE_FORMAT,
   JIRA,
   SIGNED_COMMIT,
-  TITLE_MAX_LENGTH_COUNT
+  TITLE_MAX_LENGTH_COUNT,
+  GIT_VERSION_PATTERN
 }

--- a/test/__snapshots__/gitmojiCli.spec.js.snap
+++ b/test/__snapshots__/gitmojiCli.spec.js.snap
@@ -27,6 +27,7 @@ Object {
   "CODE": "code",
   "EMOJI_FORMAT": "emojiFormat",
   "GITHUB": "github",
+  "GIT_VERSION_PATTERN": /\\^\\(\\?:\\^\\|\\\\s\\+\\)git version \\(\\[0-9\\]\\+\\)\\\\\\.\\(\\[0-9\\]\\+\\)\\\\\\.\\(\\[0-9\\]\\+\\)\\(\\?:\\\\s\\+\\|\\$\\)/i,
   "HOOK_FILE_CONTENTS": "#!/bin/sh
 # gitmoji as a commit hook
 exec < /dev/tty


### PR DESCRIPTION
## Description

The `--absolute-git-dir` option has been added to git 2.13.0. This option is used for gitmoji hook install and remove.
The stable version of debian (stretch) uses git 2.11, which prevents some members of my team from using gitmoji (they can't use stretch-backports currently).

This fix detect the current git version and use the best available method/
- Git >= 2.13: Use `--absolute-git-dir`
- Git < 2.13: Use `--git-dir` then `path.resolve` to canonicalized the absolute path

Issue: #104

## Tests

- [x] All tests passed.
