### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ gitmoji -c
 Run the init option, add your changes and commit them, after that the prompts will begin and your commit message will be built.
 
 ```bash
-$ gitmoji -i # this will create the .git/hook/prepare-commit-msg
+$ gitmoji -i # this will create the .git/hooks/prepare-commit-msg
 $ git add .
 $ git commit
 ```


### PR DESCRIPTION
A small correction in spelling.

## Description

I added the letter "s" on "hook **s**" word on README.md documentation file.

### Current
`gitmoji -i # this will create the .git/hook/prepare-commit-msg`
### And now:
`gitmoji -i # this will create the .git/hooks/prepare-commit-msg`

Issue: #
