### PR TITLE
Add "amend" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A gitmoji interactive client for using gitmojis on commit messages.
   Usage
     $ gitmoji
   Options
+    --amend, -a     Add a gitmmoji to the last commit
     --init, -i      Initialize gitmoji as a commit hook
     --remove, -r    Remove a previously initialized commit hook
     --config, -g    Setup gitmoji-cli preferences.
@@ -67,6 +68,17 @@ $ git commit
 ```
 
 ![gitmoji commit](https://cloud.githubusercontent.com/assets/7629661/20454513/5db2750a-ae43-11e6-99d7-4757108fe640.png)
+
+### Amend
+
+You can amend an icon to the last commit message using the `amend` option. This wil show a prompt to select an emoji and will prepend it to the last commit message.
+
+```bash
+$ git commit -m 'Add awesome new feature'
+$ gitmoji -a
+? Choose a gitmoji: ✨  - Introducing new features.
+[master a1b2c3d] :sparkles: Add awesome new feature
+```
 
 ### Search
 

--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ const cli = meow(`
   Usage
     $ gitmoji
   Options
-    --amend, -a     Add a gitmmoji to tha last commit
+    --amend, -a     Add a gitmmoji to the last commit
     --commit, -c    Interactively commit using the prompts
     --config, -g    Setup gitmoji-cli preferences.
     --init, -i      Initialize gitmoji as a commit hook

--- a/cli.js
+++ b/cli.js
@@ -11,6 +11,7 @@ const cli = meow(`
   Usage
     $ gitmoji
   Options
+    --amend, -a     Add a gitmmoji to tha last commit
     --commit, -c    Interactively commit using the prompts
     --config, -g    Setup gitmoji-cli preferences.
     --init, -i      Initialize gitmoji as a commit hook
@@ -24,7 +25,7 @@ const cli = meow(`
     $ gitmoji bug linter -s
 `, {
   flags: {
-    ammend: { type: 'boolean', alias: 'a' },
+    amend: { type: 'boolean', alias: 'a' },
     commit: { type: 'boolean', alias: 'c' },
     config: { type: 'boolean', alias: 'g' },
     help: { type: 'boolean', alias: 'h' },
@@ -39,6 +40,7 @@ const cli = meow(`
 
 const gitmojiCli = new GitmojiCli(utils.gitmojiApiClient)
 const options = {
+  amend: () => gitmojiCli.amend(),
   commit: () => gitmojiCli.ask('client'),
   config: () => gitmojiCli.config(),
   hook: () => gitmojiCli.ask('hook'),

--- a/cli.js
+++ b/cli.js
@@ -24,6 +24,7 @@ const cli = meow(`
     $ gitmoji bug linter -s
 `, {
   flags: {
+    ammend: { type: 'boolean', alias: 'a' },
     commit: { type: 'boolean', alias: 'c' },
     config: { type: 'boolean', alias: 'g' },
     help: { type: 'boolean', alias: 'h' },

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -92,7 +92,7 @@ class GitmojiCli {
       .catch((err) => this._errorMessage(err.code))
   }
 
-  amend() {
+  amend () {
     if (!this._isAGitRepo()) {
       return this._errorMessage('This directory is not a git repository.')
     }
@@ -101,7 +101,7 @@ class GitmojiCli {
       .then((gitmojis) => [prompts.gitmoji(gitmojis)[0]])
       .then((questions) => {
         inquirer.prompt(questions).then((answers) => {
-          return this._amend(answers.gitmoji);
+          return this._amend(answers.gitmoji)
         })
       })
       .catch(err => this._errorMessage(err.code))
@@ -146,15 +146,15 @@ class GitmojiCli {
   }
 
   _amend (icon) {
-      const commit = `git commit --amend -m"${icon} $(git log --format=%B -n1)"`;
+    const commit = `git commit --amend -m"${icon} $(git log --format=%B -n1)"`
 
-      if (!this._isAGitRepo()) {
-        return this._errorMessage('Not a git repository')
-      }
+    if (!this._isAGitRepo()) {
+      return this._errorMessage('Not a git repository')
+    }
 
-      execa.shell(commit)
-        .then((res) => console.log(chalk.blue(res.stdout)))
-        .catch((err) => this._errorMessage(err.stderr ? err.stderr : err.stdout))
+    execa.shell(commit)
+      .then((res) => console.log(chalk.blue(res.stdout)))
+      .catch((err) => this._errorMessage(err.stderr ? err.stderr : err.stdout))
   }
 
   _commit (answers) {

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -92,6 +92,21 @@ class GitmojiCli {
       .catch((err) => this._errorMessage(err.code))
   }
 
+  amend() {
+    if (!this._isAGitRepo()) {
+      return this._errorMessage('This directory is not a git repository.')
+    }
+
+    return this._fetchEmojis()
+      .then((gitmojis) => [prompts.gitmoji(gitmojis)[0]])
+      .then((questions) => {
+        inquirer.prompt(questions).then((answers) => {
+          return this._amend(answers.gitmoji);
+        })
+      })
+      .catch(err => this._errorMessage(err.code))
+  }
+
   ask (mode) {
     if (!this._isAGitRepo()) {
       return this._errorMessage('This directory is not a git repository.')
@@ -128,6 +143,18 @@ class GitmojiCli {
       return this._errorMessage(error)
     }
     process.exit(0)
+  }
+
+  _amend (icon) {
+      const commit = `git commit --amend -m"${icon} $(git log --format=%B -n1)"`;
+
+      if (!this._isAGitRepo()) {
+        return this._errorMessage('Not a git repository')
+      }
+
+      execa.shell(commit)
+        .then((res) => console.log(chalk.blue(res.stdout)))
+        .catch((err) => this._errorMessage(err.stderr ? err.stderr : err.stdout))
   }
 
   _commit (answers) {


### PR DESCRIPTION
## Description

Since I like to write long body texts in my commits, the `commit` option wasn't ideal for me.

I've now added an extra option: `gitmoji -a` or `gitmoji --amend` which shows a prompt and then prepends the selected gitmoji to the last commit.

```bash
$ git commit -m 'Add awesome new feature'
$ gitmoji -a
? Choose a gitmoji: ✨  - Introducing new features.
[master a1b2c3d] :sparkles: Add awesome new feature
```

Issue: N/A

## Tests

- [ ] All tests passed.

(It shows some errors/warnings while running the tests, but I'm not sure if it is due to my code or my local setup)