### PR TITLE
✨ Add extraArgs option

### DIFF
--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -19,7 +19,8 @@ export type Answers = {
   gitmoji: string,
   scope?: string,
   title: string,
-  message: string
+  message: string,
+  extraArgs: string
 }
 
 export default (gitmojis: Array<Gitmoji>): Array<Object> => [
@@ -62,5 +63,9 @@ export default (gitmojis: Array<Gitmoji>): Array<Object> => [
     name: 'message',
     message: 'Enter the commit message:',
     validate: guard.message
+  },
+  {
+    name: 'extraArgs',
+    message: 'Extra commit args (e.g. --fixup HEAD):'
   }
 ]

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -12,6 +12,7 @@ const withClient = async (answers: Answers) => {
     const scope = answers.scope ? `(${answers.scope}): ` : ''
     const title = `${answers.gitmoji} ${scope}${answers.title}`
     const isSigned = configurationVault.getSignedCommit() ? ['-S'] : []
+    const extraArgs = (answers.extraArgs && answers.extraArgs.split(' ')) || []
 
     if (await isHookCreated()) {
       return console.log(
@@ -26,14 +27,12 @@ const withClient = async (answers: Answers) => {
 
     if (configurationVault.getAutoAdd()) await execa('git', ['add', '.'])
 
-    const { stdout } = await execa('git', [
-      'commit',
-      ...isSigned,
-      '-m',
-      title,
-      '-m',
-      answers.message
-    ])
+    const { stdout } = await execa(
+      'git',
+      ['commit', ...isSigned, '-m', title, '-m', answers.message].concat(
+        extraArgs
+      )
+    )
 
     console.log(stdout)
   } catch (error) {

--- a/test/commands/__snapshots__/commit.spec.js.snap
+++ b/test/commands/__snapshots__/commit.spec.js.snap
@@ -32,6 +32,10 @@ Array [
     "name": "message",
     "validate": [Function],
   },
+  Object {
+    "message": "Extra commit args (e.g. --fixup HEAD):",
+    "name": "extraArgs",
+  },
 ]
 `;
 
@@ -53,6 +57,10 @@ Array [
     "message": "Enter the commit message:",
     "name": "message",
     "validate": [Function],
+  },
+  Object {
+    "message": "Extra commit args (e.g. --fixup HEAD):",
+    "name": "extraArgs",
   },
 ]
 `;
@@ -78,6 +86,10 @@ Array [
         "name": "message",
         "validate": [Function],
       },
+      Object {
+        "message": "Extra commit args (e.g. --fixup HEAD):",
+        "name": "extraArgs",
+      },
     ],
   ],
   Array [
@@ -98,6 +110,10 @@ Array [
         "message": "Enter the commit message:",
         "name": "message",
         "validate": [Function],
+      },
+      Object {
+        "message": "Extra commit args (e.g. --fixup HEAD):",
+        "name": "extraArgs",
       },
     ],
   ],
@@ -125,6 +141,10 @@ Array [
         "name": "message",
         "validate": [Function],
       },
+      Object {
+        "message": "Extra commit args (e.g. --fixup HEAD):",
+        "name": "extraArgs",
+      },
     ],
   ],
 ]
@@ -151,26 +171,9 @@ Array [
         "name": "message",
         "validate": [Function],
       },
-    ],
-  ],
-  Array [
-    Array [
       Object {
-        "message": "Choose a gitmoji:",
-        "name": "gitmoji",
-        "source": [Function],
-        "type": "autocomplete",
-      },
-      Object {
-        "message": "Enter the commit title",
-        "name": "title",
-        "transformer": [Function],
-        "validate": [Function],
-      },
-      Object {
-        "message": "Enter the commit message:",
-        "name": "message",
-        "validate": [Function],
+        "message": "Extra commit args (e.g. --fixup HEAD):",
+        "name": "extraArgs",
       },
     ],
   ],
@@ -192,6 +195,35 @@ Array [
         "message": "Enter the commit message:",
         "name": "message",
         "validate": [Function],
+      },
+      Object {
+        "message": "Extra commit args (e.g. --fixup HEAD):",
+        "name": "extraArgs",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "message": "Choose a gitmoji:",
+        "name": "gitmoji",
+        "source": [Function],
+        "type": "autocomplete",
+      },
+      Object {
+        "message": "Enter the commit title",
+        "name": "title",
+        "transformer": [Function],
+        "validate": [Function],
+      },
+      Object {
+        "message": "Enter the commit message:",
+        "name": "message",
+        "validate": [Function],
+      },
+      Object {
+        "message": "Extra commit args (e.g. --fixup HEAD):",
+        "name": "extraArgs",
       },
     ],
   ],


### PR DESCRIPTION
## Description

This can be used to provide extra arguments to the 'git commit' command, e.g. '--fixup HEAD'

## Tests

<!-- Ensure that all the tests passed -->
Snapshot was updated with `yarn jest --updateSnapshot`
- [x] All tests passed.
