### PR TITLE
🐛 Fix not escaping double quotes in commit titles

### DIFF
--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -1,6 +1,7 @@
 // @flow
 import inquirer from 'inquirer'
 
+import escapeAnswers from '../../utils/escapeAnswers'
 import getEmojis from '../../utils/getEmojis'
 import prompts from './prompts'
 import withHook from './withHook'
@@ -11,6 +12,7 @@ const commit = (mode: 'client' | 'hook') => {
     .then((gitmojis) => prompts(gitmojis))
     .then((questions) => {
       inquirer.prompt(questions).then((answers) => {
+        answers = escapeAnswers(answers)
         if (mode === 'hook') return withHook(answers)
 
         return withClient(answers)

--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -12,7 +12,7 @@ const commit = (mode: 'client' | 'hook') => {
     .then((gitmojis) => prompts(gitmojis))
     .then((questions) => {
       inquirer.prompt(questions).then((answers) => {
-        answers = escapeAnswers(answers)
+        escapeAnswers(answers)
         if (mode === 'hook') return withHook(answers)
 
         return withClient(answers)

--- a/src/utils/escapeAnswers.js
+++ b/src/utils/escapeAnswers.js
@@ -4,10 +4,10 @@ import { type Answers } from '../commands/commit/prompts'
 export const escapeAnswers = (answers: Answers) => {
   const escape = (str: string) =>
     str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-  return {
-    ...answers,
-    title: escape(answers.title),
-    message: escape(answers.message)
+  answers.title = escape(answers.title)
+  answers.message = escape(answers.message)
+  if (answers.scope !== undefined) {
+    answers.scope = escape(answers.scope)
   }
 }
 

--- a/src/utils/escapeAnswers.js
+++ b/src/utils/escapeAnswers.js
@@ -1,0 +1,14 @@
+// @flow
+import { type Answers } from '../commands/commit/prompts'
+
+export const escapeAnswers = (answers: Answers) => {
+  const escape = (str: string) =>
+    str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return {
+    ...answers,
+    title: escape(answers.title),
+    message: escape(answers.message)
+  }
+}
+
+export default escapeAnswers

--- a/test/utils/__snapshots__/escapeAnswers.spec.js.snap
+++ b/test/utils/__snapshots__/escapeAnswers.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`escapeAnswers it should escape the answers 1`] = `
+Object {
+  "gitmoji": ":zap:",
+  "message": "I am a \\\\\\"crazy\\\\\\" message :\\\\\\\\",
+  "title": "I am a \\\\\\"crazy\\\\\\" title :\\\\\\\\",
+}
+`;

--- a/test/utils/escapeAnswers.spec.js
+++ b/test/utils/escapeAnswers.spec.js
@@ -3,6 +3,7 @@ import * as stubs from './stubs'
 
 describe('escapeAnswers', () => {
   it(`it should escape the answers`, () => {
-    expect(escapeAnswers(stubs.answers)).toMatchSnapshot()
+    escapeAnswers(stubs.answers)
+    expect(stubs.answers).toMatchSnapshot()
   })
 })

--- a/test/utils/escapeAnswers.spec.js
+++ b/test/utils/escapeAnswers.spec.js
@@ -1,0 +1,8 @@
+import escapeAnswers from '../../src/utils/escapeAnswers'
+import * as stubs from './stubs'
+
+describe('escapeAnswers', () => {
+  it(`it should escape the answers`, () => {
+    expect(escapeAnswers(stubs.answers)).toMatchSnapshot()
+  })
+})

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -62,3 +62,9 @@ export const gitmojisResponse = {
 }
 
 export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'
+
+export const answers = {
+  gitmoji: ':zap:',
+  title: 'I am a "crazy" title :\\',
+  message: 'I am a "crazy" message :\\'
+}


### PR DESCRIPTION
## Description

Double quotes (`"`) and backward slashes (`\`) in commit titles and commit messages will be escaped now.

Issue: fix #148 

## Tests

- [x] All tests passed.
