### PR TITLE
Set current values as default in `gitmoji -g`

### DIFF
--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -5,7 +5,7 @@ import configurationPrompts, { CONFIGURATION_PROMPT_NAMES } from './prompts'
 import configurationVault from '../../utils/configurationVault'
 
 const config = () => {
-  inquirer.prompt(configurationPrompts).then((answers) => {
+  inquirer.prompt(configurationPrompts()).then((answers) => {
     configurationVault.setAutoAdd(answers[CONFIGURATION_PROMPT_NAMES.AUTO_ADD])
     configurationVault.setEmojiFormat(
       answers[CONFIGURATION_PROMPT_NAMES.EMOJI_FORMAT]

--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -1,4 +1,6 @@
 // @flow
+import configurationVault from '../../utils/configurationVault'
+
 export const CONFIGURATION_PROMPT_NAMES = {
   AUTO_ADD: 'autoAdd',
   EMOJI_FORMAT: 'emojiFormat',
@@ -11,11 +13,12 @@ export const EMOJI_COMMIT_FORMATS = {
   EMOJI: 'emoji'
 }
 
-export default [
+export default () => [
   {
     name: CONFIGURATION_PROMPT_NAMES.AUTO_ADD,
     message: 'Enable automatic "git add ."',
-    type: 'confirm'
+    type: 'confirm',
+    default: configurationVault.getAutoAdd()
   },
   {
     name: CONFIGURATION_PROMPT_NAMES.EMOJI_FORMAT,
@@ -24,16 +27,19 @@ export default [
     choices: [
       { name: ':smile:', value: EMOJI_COMMIT_FORMATS.CODE },
       { name: '😄', value: EMOJI_COMMIT_FORMATS.EMOJI }
-    ]
+    ],
+    default: configurationVault.getEmojiFormat()
   },
   {
     name: CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT,
     message: 'Enable signed commits',
-    type: 'confirm'
+    type: 'confirm',
+    default: configurationVault.getSignedCommit()
   },
   {
     name: CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT,
     message: 'Enable scope prompt',
-    type: 'confirm'
+    type: 'confirm',
+    default: configurationVault.getScopePrompt()
   }
 ]

--- a/test/commands/config.spec.js
+++ b/test/commands/config.spec.js
@@ -14,7 +14,7 @@ describe('config command', () => {
   })
 
   it('should call inquirer.prompt with configuration prompts', () => {
-    expect(inquirer.prompt).toHaveBeenCalledWith(configurationPrompts)
+    expect(inquirer.prompt).toHaveBeenCalledWith(configurationPrompts())
   })
 
   it('should save the answers into the configuration vault', () => {


### PR DESCRIPTION
Set the current config values as default when using `gitmoji -g`.
This is very useful when you want to change a single value.