### PR TITLE
Ignore hook if not creating a new commit, from a TTY

### DIFF
--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -4,8 +4,11 @@ const HOOK: Object = {
   PATH: '/hooks/prepare-commit-msg',
   CONTENTS: `#!/bin/sh
 # gitmoji as a commit hook
-exec < /dev/tty
-gitmoji --hook $1
+if test -t 1 && ! grep -q -m 1 '^[^#]' $1; then
+  # it has been invoked from a tty and no commit message is already set
+  exec < /dev/tty
+  gitmoji --hook $1
+fi
 `
 }
 

--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -2,9 +2,11 @@
 const HOOK: Object = {
   PERMISSIONS: 0o775,
   PATH: '/hooks/prepare-commit-msg',
-  CONTENTS:
-    '#!/bin/sh\n# gitmoji as a commit hook\n' +
-    'exec < /dev/tty\ngitmoji --hook $1\n'
+  CONTENTS: `#!/bin/sh
+# gitmoji as a commit hook
+exec < /dev/tty
+gitmoji --hook $1
+`
 }
 
 export default HOOK

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -4,8 +4,11 @@ exports[`hook command should match hook configuration 1`] = `
 Object {
   "CONTENTS": "#!/bin/sh
 # gitmoji as a commit hook
-exec < /dev/tty
-gitmoji --hook $1
+if test -t 1 && ! grep -q -m 1 '^[^#]' $1; then
+  # it has been invoked from a tty and no commit message is already set
+  exec < /dev/tty
+  gitmoji --hook $1
+fi
 ",
   "PATH": "/hooks/prepare-commit-msg",
   "PERMISSIONS": 509,


### PR DESCRIPTION
## Description
Ignore hook if not creating a _new_ commit, from a TTY

It solves and supersedes https://github.com/carloscuesta/gitmoji-cli/pull/112: Ignore hook when rebasing.

## Tests
- [x] All tests passed.