### PR TITLE
🐛 Check pre-commit-hook for contents

### DIFF
--- a/src/utils/isHookCreated.js
+++ b/src/utils/isHookCreated.js
@@ -8,7 +8,10 @@ const isHookCreated = async () => {
   try {
     const { stdout } = await execa('git', ['rev-parse', '--absolute-git-dir'])
 
-    return fs.existsSync(stdout + HOOK.PATH)
+    if (!fs.existsSync(stdout + HOOK.PATH)) {
+      return false
+    }
+    return fs.readFileSync(stdout + HOOK.PATH) === HOOK.CONTENTS
   } catch (error) {
     console.error(error)
   }

--- a/test/utils/isHookCreated.spec.js
+++ b/test/utils/isHookCreated.spec.js
@@ -8,17 +8,26 @@ import * as stubs from './stubs'
 describe('isHookCreated', () => {
   beforeAll(() => {
     execa.mockReturnValue({ stdout: stubs.gitAbsoluteDir })
-    isHookCreated()
   })
 
   it('should obtain the absolute git dir with execa', () => {
+    isHookCreated()
     expect(execa).toHaveBeenCalledWith('git', [
       'rev-parse',
       '--absolute-git-dir'
     ])
   })
 
-  it('should check if hook file exists', () => {
+  it('should check if hook file exists', async () => {
+    expect(await isHookCreated()).toEqual(false)
     expect(fs.existsSync).toHaveBeenCalledWith(stubs.gitAbsoluteDir + HOOK.PATH)
+  })
+
+  it('should check if hook file matches', async () => {
+    fs.existsSync.mockReturnValue(true)
+    expect(await isHookCreated()).toEqual(false)
+    expect(fs.readFileSync).toHaveBeenCalledWith(
+      stubs.gitAbsoluteDir + HOOK.PATH
+    )
   })
 })


### PR DESCRIPTION
Prevents accidentally matching another hook (e.g. Husky) as a collision.

## Tests

- [X] All tests passed.
