### PR TITLE
Add scope template

### DIFF
--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -9,7 +9,11 @@ import { type Answers } from '../prompts'
 
 const withClient = async (answers: Answers) => {
   try {
-    const scope = answers.scope ? `(${answers.scope}): ` : ''
+    const scopeTemplate = configurationVault.getScopeTemplate()
+
+    const scope = answers.scope
+      ? scopeTemplate.replace('%s', answers.scope)
+      : ''
     const title = `${answers.gitmoji} ${scope}${answers.title}`
     const isSigned = configurationVault.getSignedCommit() ? ['-S'] : []
 

--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -16,6 +16,9 @@ const config = () => {
     configurationVault.setScopePrompt(
       answers[CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT]
     )
+    configurationVault.setScopeTemplate(
+      answers[CONFIGURATION_PROMPT_NAMES.SCOPE_TEMPLATE]
+    )
   })
 }
 

--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -5,6 +5,7 @@ export const CONFIGURATION_PROMPT_NAMES = {
   AUTO_ADD: 'autoAdd',
   EMOJI_FORMAT: 'emojiFormat',
   SCOPE_PROMPT: 'scopePrompt',
+  SCOPE_TEMPLATE: 'scopeTemplate',
   SIGNED_COMMIT: 'signedCommit'
 }
 
@@ -41,5 +42,12 @@ export default () => [
     message: 'Enable scope prompt',
     type: 'confirm',
     default: configurationVault.getScopePrompt()
+  },
+  {
+    name: CONFIGURATION_PROMPT_NAMES.SCOPE_TEMPLATE,
+    message:
+      'Type a template for the scope (any "%s" will be replaced by the scope)',
+    type: 'input',
+    default: configurationVault.getScopeTemplate()
   }
 ]

--- a/src/utils/configurationVault.js
+++ b/src/utils/configurationVault.js
@@ -24,6 +24,10 @@ const setScopePrompt = (scopePrompt: boolean) => {
   config.set(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT, scopePrompt)
 }
 
+const setScopeTemplate = (scopeTemplate: string) => {
+  config.set(CONFIGURATION_PROMPT_NAMES.SCOPE_TEMPLATE, scopeTemplate)
+}
+
 const getAutoAdd = (): boolean => {
   return config.get(CONFIGURATION_PROMPT_NAMES.AUTO_ADD) || false
 }
@@ -43,13 +47,19 @@ const getScopePrompt = (): boolean => {
   return config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT) || false
 }
 
+const getScopeTemplate = (): string => {
+  return config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_TEMPLATE) || '(%s): '
+}
+
 export default {
   getAutoAdd,
   getEmojiFormat,
   getScopePrompt,
+  getScopeTemplate,
   getSignedCommit,
   setAutoAdd,
   setEmojiFormat,
   setScopePrompt,
+  setScopeTemplate,
   setSignedCommit
 }

--- a/test/commands/__snapshots__/commit.spec.js.snap
+++ b/test/commands/__snapshots__/commit.spec.js.snap
@@ -104,6 +104,74 @@ Array [
 ]
 `;
 
+exports[`commit command withClient with custom scope should call inquirer with prompts 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "message": "Choose a gitmoji:",
+        "name": "gitmoji",
+        "source": [Function],
+        "type": "autocomplete",
+      },
+      Object {
+        "message": "Enter the commit title",
+        "name": "title",
+        "transformer": [Function],
+        "validate": [Function],
+      },
+      Object {
+        "message": "Enter the commit message:",
+        "name": "message",
+        "validate": [Function],
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "message": "Choose a gitmoji:",
+        "name": "gitmoji",
+        "source": [Function],
+        "type": "autocomplete",
+      },
+      Object {
+        "message": "Enter the commit title",
+        "name": "title",
+        "transformer": [Function],
+        "validate": [Function],
+      },
+      Object {
+        "message": "Enter the commit message:",
+        "name": "message",
+        "validate": [Function],
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "message": "Choose a gitmoji:",
+        "name": "gitmoji",
+        "source": [Function],
+        "type": "autocomplete",
+      },
+      Object {
+        "message": "Enter the commit title",
+        "name": "title",
+        "transformer": [Function],
+        "validate": [Function],
+      },
+      Object {
+        "message": "Enter the commit message:",
+        "name": "message",
+        "validate": [Function],
+      },
+    ],
+  ],
+]
+`;
+
 exports[`commit command withClient with no autoAdd and no signed commits and no scope should call inquirer with prompts 1`] = `
 Array [
   Array [
@@ -132,6 +200,27 @@ Array [
 
 exports[`commit command withClient with the commit hook created should call inquirer with prompts 1`] = `
 Array [
+  Array [
+    Array [
+      Object {
+        "message": "Choose a gitmoji:",
+        "name": "gitmoji",
+        "source": [Function],
+        "type": "autocomplete",
+      },
+      Object {
+        "message": "Enter the commit title",
+        "name": "title",
+        "transformer": [Function],
+        "validate": [Function],
+      },
+      Object {
+        "message": "Enter the commit message:",
+        "name": "message",
+        "validate": [Function],
+      },
+    ],
+  ],
   Array [
     Array [
       Object {

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -59,6 +59,7 @@ describe('commit command', () => {
         isHookCreated.mockResolvedValue(false)
         configurationVault.getAutoAdd.mockReturnValue(true)
         configurationVault.getSignedCommit.mockReturnValue(true)
+        configurationVault.getScopeTemplate.mockReturnValue('(%s): ')
         commit('client')
       })
 
@@ -76,6 +77,40 @@ describe('commit command', () => {
           '-S',
           '-m',
           `${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}`,
+          '-m',
+          stubs.clientCommitAnswersWithScope.message
+        ])
+      })
+
+      it('should print the result to the console', () => {
+        expect(console.log).toHaveBeenCalledWith(stubs.commitResult)
+      })
+    })
+
+    describe('with custom scope', () => {
+      beforeAll(() => {
+        console.log = jest.fn()
+        execa.mockReturnValue({ stdout: stubs.commitResult })
+        inquirer.prompt.mockReturnValue(
+          Promise.resolve(stubs.clientCommitAnswersWithScope)
+        )
+        getEmojis.mockResolvedValue(stubs.gitmojis)
+        isHookCreated.mockResolvedValue(false)
+        configurationVault.getAutoAdd.mockReturnValue(false)
+        configurationVault.getSignedCommit.mockReturnValue(false)
+        configurationVault.getScopeTemplate.mockReturnValue('[%s] ')
+        commit('client')
+      })
+
+      it('should call inquirer with prompts', () => {
+        expect(inquirer.prompt.mock.calls).toMatchSnapshot()
+      })
+
+      it('should call execa with the commit command based on answers', () => {
+        expect(execa).toHaveBeenLastCalledWith('git', [
+          'commit',
+          '-m',
+          `${stubs.clientCommitAnswersWithScope.gitmoji} [${stubs.clientCommitAnswersWithScope.scope}] ${stubs.clientCommitAnswersWithScope.title}`,
           '-m',
           stubs.clientCommitAnswersWithScope.message
         ])

--- a/test/commands/config.spec.js
+++ b/test/commands/config.spec.js
@@ -30,5 +30,8 @@ describe('config command', () => {
     expect(configurationVault.setScopePrompt).toHaveBeenCalledWith(
       stubs.configAnswers.scopePrompt
     )
+    expect(configurationVault.setScopeTemplate).toHaveBeenCalledWith(
+      stubs.configAnswers.scopeTemplate
+    )
   })
 })

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -19,7 +19,8 @@ export const configAnswers = {
   autoAdd: true,
   emojiFormat: 'emoji',
   signedCommit: true,
-  scopePrompt: false
+  scopePrompt: false,
+  scopeTemplate: '(%s): '
 }
 
 export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'

--- a/test/utils/__snapshots__/configurationVault.spec.js.snap
+++ b/test/utils/__snapshots__/configurationVault.spec.js.snap
@@ -5,10 +5,12 @@ Object {
   "getAutoAdd": [Function],
   "getEmojiFormat": [Function],
   "getScopePrompt": [Function],
+  "getScopeTemplate": [Function],
   "getSignedCommit": [Function],
   "setAutoAdd": [Function],
   "setEmojiFormat": [Function],
   "setScopePrompt": [Function],
+  "setScopeTemplate": [Function],
   "setSignedCommit": [Function],
 }
 `;

--- a/test/utils/configurationVault.spec.js
+++ b/test/utils/configurationVault.spec.js
@@ -29,6 +29,10 @@ describe('configurationVault', () => {
     it('should return the default value for scopePrompt', () => {
       expect(configurationVault.getScopePrompt()).toEqual(false)
     })
+
+    it('should return the default value for scopeTemplate', () => {
+      expect(configurationVault.getScopeTemplate()).toEqual('(%s): ')
+    })
   })
 
   describe('setter and getters', () => {
@@ -80,16 +84,16 @@ describe('configurationVault', () => {
       )
     })
 
-    it('should set and return value for signedCommit', () => {
-      configurationVault.setScopePrompt(true)
-      configurationVault.getScopePrompt()
+    it('should set and return value for scopeTemplate', () => {
+      configurationVault.setScopeTemplate('[%s] ')
+      configurationVault.getScopeTemplate()
 
       expect(config.set).toHaveBeenCalledWith(
-        CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT,
-        true
+        CONFIGURATION_PROMPT_NAMES.SCOPE_TEMPLATE,
+        '[%s] '
       )
       expect(config.get).toHaveBeenCalledWith(
-        CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT
+        CONFIGURATION_PROMPT_NAMES.SCOPE_TEMPLATE
       )
     })
   })


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
> **TL;DR:**
> I wanted to change the way `gitmoji-cli` added scope to commit, so I added an option to do it

I started using gitmoji without cli, then, I saw about the convetion some people use about adding a scope to the commit instead of mention it in the actuall commit message. I started using the model [`:sparkles: [nvim] open terminal at vertical split`](https://github.com/vhoyer/dotfiles/commits). After some time I started using the CLI, because it is more convinient. Now, 3 hours ago, I discovered that there was the option to config `gitmoji-cli` to prompt for the scope part of the commit. I saw the model in current use (`(scope): `) and didn't like it since I was using this other template (`[scope] `).

Motivated by this I added the option in `--config` to set a custom template for the scope part of the commit in the interactive commit insertion provided by this repo :D

I'd very much appreciate to start using this feature soon on my repo with the official package :D

<!-- Add issue number that this pull request refers to -->
Issue: `#what issue?`

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
