### PR TITLE
Improvements for hook mode

### DIFF
--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -2,6 +2,7 @@
 import inquirer from 'inquirer'
 
 import configurationVault from '../../utils/configurationVault'
+import getDefaultCommitContent from '../../utils/getDefaultCommitContent'
 import guard from './guard'
 
 const TITLE_MAX_LENGTH_COUNT: number = 48
@@ -22,45 +23,52 @@ export type Answers = {
   message: string
 }
 
-export default (gitmojis: Array<Gitmoji>): Array<Object> => [
-  {
-    name: 'gitmoji',
-    message: 'Choose a gitmoji:',
-    type: 'autocomplete',
-    source: (answersSoFor: any, input: string) => {
-      return Promise.resolve(
-        gitmojis
-          .filter((gitmoji) => {
-            const emoji = gitmoji.name.concat(gitmoji.description).toLowerCase()
-            return !input || emoji.indexOf(input.toLowerCase()) !== -1
-          })
-          .map((gitmoji) => ({
-            name: `${gitmoji.emoji}  - ${gitmoji.description}`,
-            value: gitmoji[configurationVault.getEmojiFormat()]
-          }))
-      )
+export default (gitmojis: Array<Gitmoji>): Array<Object> => {
+  const { title, message } = getDefaultCommitContent()
+  return [
+    {
+      name: 'gitmoji',
+      message: 'Choose a gitmoji:',
+      type: 'autocomplete',
+      source: (answersSoFor: any, input: string) => {
+        return Promise.resolve(
+          gitmojis
+            .filter((gitmoji) => {
+              const emoji = gitmoji.name
+                .concat(gitmoji.description)
+                .toLowerCase()
+              return !input || emoji.indexOf(input.toLowerCase()) !== -1
+            })
+            .map((gitmoji) => ({
+              name: `${gitmoji.emoji}  - ${gitmoji.description}`,
+              value: gitmoji[configurationVault.getEmojiFormat()]
+            }))
+        )
+      }
+    },
+    ...(configurationVault.getScopePrompt()
+      ? [
+          {
+            name: 'scope',
+            message: 'Enter the scope of current changes:',
+            validate: guard.scope
+          }
+        ]
+      : []),
+    {
+      name: 'title',
+      message: 'Enter the commit title',
+      validate: guard.title,
+      transformer: (input: string) => {
+        return `[${input.length}/${TITLE_MAX_LENGTH_COUNT}]: ${input}`
+      },
+      ...(title ? { default: title } : {})
+    },
+    {
+      name: 'message',
+      message: 'Enter the commit message:',
+      validate: guard.message,
+      ...(title && message ? { default: message } : {})
     }
-  },
-  ...(configurationVault.getScopePrompt()
-    ? [
-        {
-          name: 'scope',
-          message: 'Enter the scope of current changes:',
-          validate: guard.scope
-        }
-      ]
-    : []),
-  {
-    name: 'title',
-    message: 'Enter the commit title',
-    validate: guard.title,
-    transformer: (input: string) => {
-      return `[${input.length}/${TITLE_MAX_LENGTH_COUNT}]: ${input}`
-    }
-  },
-  {
-    name: 'message',
-    message: 'Enter the commit message:',
-    validate: guard.message
-  }
-]
+  ]
+}

--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -1,10 +1,27 @@
 // @flow
+
+const CONTENTS = `#! /bin/bash
+# gitmoji as a commit hook
+
+# strict mode for bash
+set -eo pipefail
+IFS=$'\\n\\t'
+
+readonly COMMIT_MSG_FILE=$1
+# no undefined variables
+set -u
+
+BRANCH_NAME="$(git branch | sed -e 's/* //')"
+if [[ ! "$BRANCH_NAME" =~ 'no branch' ]]; then
+  exec < /dev/tty
+  gitmoji --hook "$COMMIT_MSG_FILE"
+fi
+`
+
 const HOOK: Object = {
   PERMISSIONS: 0o775,
   PATH: '/hooks/prepare-commit-msg',
-  CONTENTS:
-    '#!/bin/sh\n# gitmoji as a commit hook\n' +
-    'exec < /dev/tty\ngitmoji --hook $1\n'
+  CONTENTS
 }
 
 export default HOOK

--- a/src/utils/getDefaultCommitContent.js
+++ b/src/utils/getDefaultCommitContent.js
@@ -1,0 +1,23 @@
+// @flow
+import fs from 'fs'
+
+const getDefaultCommitContent = () => {
+  try {
+    const commitFilePath: string = process.argv[3]
+    const commitFileContent: Array<string> = fs
+      .readFileSync(commitFilePath)
+      .toString()
+      .split('\n')
+    return {
+      title: commitFileContent.length ? commitFileContent[0] : '',
+      message: commitFileContent.length >= 3 ? commitFileContent[2] : ''
+    }
+  } catch (e) {
+    return {
+      title: '',
+      message: ''
+    }
+  }
+}
+
+export default getDefaultCommitContent

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -2,10 +2,22 @@
 
 exports[`hook command should match hook configuration 1`] = `
 Object {
-  "CONTENTS": "#!/bin/sh
+  "CONTENTS": "#! /bin/bash
 # gitmoji as a commit hook
-exec < /dev/tty
-gitmoji --hook $1
+
+# strict mode for bash
+set -eo pipefail
+IFS=$'\\\\n\\\\t'
+
+readonly COMMIT_MSG_FILE=$1
+# no undefined variables
+set -u
+
+BRANCH_NAME=\\"$(git branch | sed -e 's/* //')\\"
+if [[ ! \\"$BRANCH_NAME\\" =~ 'no branch' ]]; then
+  exec < /dev/tty
+  gitmoji --hook \\"$COMMIT_MSG_FILE\\"
+fi
 ",
   "PATH": "/hooks/prepare-commit-msg",
   "PERMISSIONS": 509,


### PR DESCRIPTION
## Description

Two improvements:

- Prevent the hook from being run when doing an interactive rebase
- Allow users to pre-fill the commit title and message when running `git commit -m "My custom title" -m "My custom message"`
![image](https://user-images.githubusercontent.com/19605940/71404640-66511980-2633-11ea-92d6-b5ad6572b07b.png)
![image](https://user-images.githubusercontent.com/19605940/71404657-6ea95480-2633-11ea-8806-b2f8a929b3c5.png)
Result when pressing `Enter` on title and message steps:
![image](https://user-images.githubusercontent.com/19605940/71404879-0444e400-2634-11ea-953a-e6ecc8bdebe4.png)


This last feature will allow users to keep the commits title and message in their shell history, which I found greatly improves the cli's experience.

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
