### PR TITLE
🐛 Commit hook skips prompt when using verbose flag (Closes #313)

### DIFF
--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -4,12 +4,22 @@ const HOOK: Object = {
   PATH: '/hooks/prepare-commit-msg',
   CONTENTS: `#!/bin/sh
 # gitmoji as a commit hook
-if test -t 1 && ! grep -q -m 1 '^[^#]' $1; then
+commit_message_empty=true
+while read line
+do
+  if [[ $line == "# ------------------------ >8 ------------------------"* ]]; then
+    break
+  elif [[ $line != "#"* && $line != "" ]]; then
+    commit_message_empty=false
+    break
+  fi
+done < $1
+
+if test -t 1 && $commit_message_empty; then
   # it has been invoked from a tty and no commit message is already set
   exec < /dev/tty
   gitmoji --hook $1
-fi
-`
+fi`
 }
 
 export default HOOK

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -4,12 +4,22 @@ exports[`hook command should match hook configuration 1`] = `
 Object {
   "CONTENTS": "#!/bin/sh
 # gitmoji as a commit hook
-if test -t 1 && ! grep -q -m 1 '^[^#]' $1; then
+commit_message_empty=true
+while read line
+do
+  if [[ $line == \\"# ------------------------ >8 ------------------------\\"* ]]; then
+    break
+  elif [[ $line != \\"#\\"* && $line != \\"\\" ]]; then
+    commit_message_empty=false
+    break
+  fi
+done < $1
+
+if test -t 1 && $commit_message_empty; then
   # it has been invoked from a tty and no commit message is already set
   exec < /dev/tty
   gitmoji --hook $1
-fi
-",
+fi",
   "PATH": "/hooks/prepare-commit-msg",
   "PERMISSIONS": 509,
 }


### PR DESCRIPTION
## Description

The Bash hook script now iterates through all lines in the staged commit message file and checks if they are not empty. Lines below the snip - introduced when committing with the `--verbose` flag - are ignored, as they are ignored by Git and as such do not contribute to the commit message. 

Issue: #313

## Tests

- [x] All tests passed.
