### PR TITLE
🐛 Reduced sum of search weights to equal 1

### DIFF
--- a/src/utils/filterGitmojis.js
+++ b/src/utils/filterGitmojis.js
@@ -3,7 +3,7 @@ import Fuse from 'fuse.js'
 
 import { type Gitmoji } from '../commands/commit/prompts'
 
-const options = {
+export const options = {
   threshold: 0.5,
   keys: [
     {

--- a/src/utils/filterGitmojis.js
+++ b/src/utils/filterGitmojis.js
@@ -8,11 +8,11 @@ const options = {
   keys: [
     {
       name: 'name',
-      weight: 0.5
+      weight: 0.33
     },
     {
       name: 'description',
-      weight: 1
+      weight: 0.67
     }
   ]
 }

--- a/test/utils/filterGitmojis.spec.js
+++ b/test/utils/filterGitmojis.spec.js
@@ -1,4 +1,4 @@
-import filterGitmojis from '../../src/utils/filterGitmojis'
+import filterGitmojis, { options } from '../../src/utils/filterGitmojis'
 import * as stubs from './stubs'
 
 describe('filterGirmojis', () => {
@@ -38,5 +38,11 @@ describe('filterGirmojis', () => {
 
     const gitmoji = stubs.gitmojis.find((gitmoji) => gitmoji.name === 'alien')
     expect(filteredGitmojis[0]).toStrictEqual(gitmoji)
+  })
+
+  it('should not have a total weight of greater than 1', () => {
+    const weightSum = options.keys.reduce((carry, key) => carry += key.weight, 0)
+
+    expect(weightSum).toBeLessThanOrEqual(1)
   })
 })


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
Version 3.6.0 of Fuse.js introduced an exception when the total weights of all the keys is > 1.

https://github.com/krisk/Fuse/commit/1fb86f0ebd8bba374d81ef4b8ffa8a296cd7898e#diff-1fdf421c05c1140f6d71444ea2b27638R137-R139

This PR updates the key weights to match the existing ratios, but with the total weight being 1. Additionally, a new test case exists to ensure the weights remain equal or under 1.

<!-- Add issue number that this pull request refers to -->
Issue: #324

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
