### PR TITLE
Fix hook abort with ctrl-c behavior to match v3.0.0

### DIFF
--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -3,10 +3,12 @@ import inquirer from 'inquirer'
 
 import getEmojis from '../../utils/getEmojis'
 import prompts from './prompts'
-import withHook from './withHook'
+import withHook, { registerHookInterruptionHandler } from './withHook'
 import withClient from './withClient'
 
 const commit = (mode: 'client' | 'hook') => {
+  if (mode === 'hook') registerHookInterruptionHandler()
+
   return getEmojis()
     .then((gitmojis) => prompts(gitmojis))
     .then((questions) => {

--- a/src/commands/commit/withHook/index.js
+++ b/src/commands/commit/withHook/index.js
@@ -18,4 +18,12 @@ const withHook = (answers: Answers) => {
   }
 }
 
+export const registerHookInterruptionHandler = () => {
+  // Allow to interrupt the hook without cancelling the commit
+  process.on('SIGINT', () => {
+    console.warn('gitmoji-cli was interrupted')
+    process.exit(0)
+  })
+}
+
 export default withHook


### PR DESCRIPTION
## Description
meow version update introduce a bug with the crl-c behavior of gitmoji: the commit is aborded instead of proceeding without gitmoji.
<!-- Explanation about your pull request, what changes you've made -->
I pinned the version of meow to the last version without the bug.
<!-- Add issue number that this pull request refers to -->
Issue: #266

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
