### PR TITLE
Re-add hook content changes

### DIFF
--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -2,9 +2,29 @@
 const HOOK: Object = {
   PERMISSIONS: 0o775,
   PATH: '/hooks/prepare-commit-msg',
-  CONTENTS:
-    '#!/bin/sh\n# gitmoji as a commit hook\n' +
-    'exec < /dev/tty\ngitmoji --hook $1\n'
+  CONTENTS: `#!/bin/sh
+# gitmoji as a commit hook
+commit_message_empty=true
+while read -r line
+do
+  case "$line" in
+  "# ------------------------ >8 ------------------------"*)
+    break
+    ;;
+  ""|"#"*)
+    # skip
+    ;;
+  *)
+    commit_message_empty=false
+    break
+    ;;
+  esac
+done < "$1"
+if test -t 1 && $commit_message_empty; then
+  # it has been invoked from a tty and no commit message is already set
+  exec < /dev/tty
+  gitmoji --hook "$1"
+fi`
 }
 
 export default HOOK

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -4,9 +4,27 @@ exports[`hook command should match hook configuration 1`] = `
 Object {
   "CONTENTS": "#!/bin/sh
 # gitmoji as a commit hook
-exec < /dev/tty
-gitmoji --hook $1
-",
+commit_message_empty=true
+while read -r line
+do
+  case \\"$line\\" in
+  \\"# ------------------------ >8 ------------------------\\"*)
+    break
+    ;;
+  \\"\\"|\\"#\\"*)
+    # skip
+    ;;
+  *)
+    commit_message_empty=false
+    break
+    ;;
+  esac
+done < \\"$1\\"
+if test -t 1 && $commit_message_empty; then
+  # it has been invoked from a tty and no commit message is already set
+  exec < /dev/tty
+  gitmoji --hook \\"$1\\"
+fi",
   "PATH": "/hooks/prepare-commit-msg",
   "PERMISSIONS": 509,
 }


### PR DESCRIPTION
Re-add **fixed** hook content changes:
- https://github.com/carloscuesta/gitmoji-cli/commit/d8ec4d11502425fa1eecde290ad797f8c876e86b#diff-1e69352ce20a8767469d44f951b132a9
- https://github.com/carloscuesta/gitmoji-cli/commit/d33a26bb7003efd2c3a880cc94bf8cc4da80ff30#diff-1e69352ce20a8767469d44f951b132a9

These changes were canceled by https://github.com/carloscuesta/gitmoji-cli/commit/c668e779d4866188c7fe8a3b7be8d56309e065d0 due to https://github.com/carloscuesta/gitmoji-cli/issues/330 .
The problems were caused by the use of bash syntaxes (not compatible with POSIX sh).
Now the script is fully compliant with POSIX sh!