### PR TITLE
✨ Cancel hook when a git message is already set

### DIFF
--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -3,11 +3,17 @@ import inquirer from 'inquirer'
 
 import getEmojis from '../../utils/getEmojis'
 import prompts from './prompts'
-import withHook, { registerHookInterruptionHandler } from './withHook'
+import withHook, {
+  registerHookInterruptionHandler,
+  cancelIfMessageIsAlreadySet
+} from './withHook'
 import withClient from './withClient'
 
 const commit = (mode: 'client' | 'hook') => {
-  if (mode === 'hook') registerHookInterruptionHandler()
+  if (mode === 'hook') {
+    cancelIfMessageIsAlreadySet()
+    registerHookInterruptionHandler()
+  }
 
   return getEmojis()
     .then((gitmojis) => prompts(gitmojis))

--- a/src/commands/commit/withHook/index.js
+++ b/src/commands/commit/withHook/index.js
@@ -26,4 +26,16 @@ export const registerHookInterruptionHandler = () => {
   })
 }
 
+export const cancelIfMessageIsAlreadySet = () => {
+  const commitMessageFilePath = process.argv[3]
+  if (
+    fs.existsSync(commitMessageFilePath) &&
+    fs.lstatSync(commitMessageFilePath).isFile() &&
+    !!fs.readFileSync(commitMessageFilePath, 'utf8')
+  ) {
+    console.warn('A commit message is already set, cancelling gitmoji\n')
+    process.exit(0)
+  }
+}
+
 export default withHook

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -156,6 +156,33 @@ describe('commit command', () => {
         expect(process.exit).toHaveBeenCalledWith(0)
       })
     })
+
+    describe('when the commit message is already defined', () => {
+      it('should cancel the hook', async () => {
+        const warnConsoleSpy = jest
+          .spyOn(console, 'warn')
+          .mockImplementationOnce()
+
+        // Use an exception to suspend code execution to simulate process.exit
+        mockProcess.mockProcessExit(new Error('ProcessExit0'))
+        fs.existsSync.mockReturnValueOnce(true)
+        fs.lstatSync.mockReturnValueOnce({ isFile: () => true })
+        fs.readFileSync.mockReturnValueOnce('message')
+        process.argv[3] = stubs.argv
+
+        try {
+          await commit('hook')
+        } catch (e) {
+          expect(e.message).toMatch('ProcessExit0')
+        }
+
+        expect(warnConsoleSpy).toHaveBeenCalledWith(
+          'A commit message is already set, cancelling gitmoji\n'
+        )
+        expect(process.exit).toHaveBeenCalledWith(0)
+      })
+    })
+
     describe('when receiving a signal interrupt', () => {
       it('should call process.exit(0)', async () => {
         const warnConsoleSpy = jest.spyOn(console, 'warn').mockImplementation()


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
Hi @carloscuesta ,

At first I just wanted to build end to end tests over @nathan818fr [pull request](https://github.com/carloscuesta/gitmoji-cli/pull/366). However there are numerous difficulties in doing a true E2E testing of a CLI app. The deal breaker for gitmoji being that inquirer doesn't handle piping to answer. I also tried to mock some libs like inquirer to avoid the prompt but still use a classic `git commit` flow to trigger the `prepare-commit-msg` hook without success.

My last idea was to use some remotely controllable terminal to deal with the interactivity of inquirer (similar in principle to cypress for web app), but except [kitty terminal](https://sw.kovidgoyal.net/kitty/#remote-control), I don't know another terminal that implement this feature and as kitty is still recent, I figured it wasn't a good fit since stability isn't reached yet and checked out this idea as well.

Since I couldn't figure out a way of doing such e2e tests in a reliable and cross platform way, I choose to go back to the source of the problem:
- The hook is always triggered when committing even on rebase, cherry-pick, amend, etc.
- Implementing the logic of not triggering the hook when the git message is already defined should be done in a plateform agnostic way, which as shown by https://github.com/carloscuesta/gitmoji-cli/issues/330 is no small task.

Finally, I tried a small proof of concept for a pure js implementation in gitmoji and figured out it was quite an easy and elegant solution with the added benefit of being easy to test.

## Issues
<!-- Add issue number that this pull request refers to -->
Issue: https://github.com/carloscuesta/gitmoji-cli/issues/330
Issue: https://github.com/carloscuesta/gitmoji-cli/issues/397
blocked pr: https://github.com/carloscuesta/gitmoji-cli/pull/366

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
