### PR TITLE
✨ Cancel hook on rebase

### DIFF
--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -3,15 +3,25 @@ import inquirer from 'inquirer'
 
 import getEmojis from '../../utils/getEmojis'
 import prompts from './prompts'
-import withHook, { registerHookInterruptionHandler } from './withHook'
+import withHook, {
+  registerHookInterruptionHandler,
+  cancelIfRebasing
+} from './withHook'
 import withClient from './withClient'
 
 export type CommitMode = 'client' | 'hook'
 
 const commit = (mode: CommitMode) => {
-  if (mode === 'hook') registerHookInterruptionHandler()
+  if (mode === 'hook') {
+    registerHookInterruptionHandler()
+    return cancelIfRebasing().then(() => promptAndCommit(mode))
+  }
 
-  return getEmojis()
+  return promptAndCommit(mode)
+}
+
+const promptAndCommit = (mode: 'client' | 'hook') =>
+  getEmojis()
     .then((gitmojis) => prompts(gitmojis, mode))
     .then((questions) => {
       inquirer.prompt(questions).then((answers) => {
@@ -20,6 +30,5 @@ const commit = (mode: CommitMode) => {
         return withClient(answers)
       })
     })
-}
 
 export default commit

--- a/src/commands/commit/withHook/index.js
+++ b/src/commands/commit/withHook/index.js
@@ -1,4 +1,5 @@
 // @flow
+import execa from 'execa'
 import fs from 'fs'
 
 import { type Answers } from '../prompts'
@@ -25,5 +26,19 @@ export const registerHookInterruptionHandler = () => {
     process.exit(0)
   })
 }
+
+export const cancelIfRebasing = () =>
+  execa('git', ['rev-parse', '--absolute-git-dir']).then(
+    ({ stdout: gitDirectory }) => {
+      // see https://stackoverflow.com/questions/3921409/how-to-know-if-there-is-a-git-rebase-in-progress
+      // to understand how a rebase is detected
+      if (
+        fs.existsSync(gitDirectory + '/rebase-merge') ||
+        fs.existsSync(gitDirectory + '/rebase-apply')
+      ) {
+        process.exit(0)
+      }
+    }
+  )
 
 export default withHook


### PR DESCRIPTION
## Description
Hi @carloscuesta, I recreated the feature to cancel the hook on rebase.

Noteworthy point, I contacted @adriencaccia, which implemented a elegant solution on a fork to prefill the commit message in this case, he will come back to you with a proposition .

<!-- Explanation about your pull request, what changes you've made -->

<!-- Add issue number that this pull request refers to -->
Issue: https://github.com/carloscuesta/gitmoji-cli/issues/444

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
