### PR TITLE
✨ Prefill title and message in hook mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ coverage/
 lib/
 bin/
 package-lock.json
+
+# VS Code settings
+.vscode

--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -6,11 +6,13 @@ import prompts from './prompts'
 import withHook, { registerHookInterruptionHandler } from './withHook'
 import withClient from './withClient'
 
-const commit = (mode: 'client' | 'hook') => {
+export type CommitMode = 'client' | 'hook'
+
+const commit = (mode: CommitMode) => {
   if (mode === 'hook') registerHookInterruptionHandler()
 
   return getEmojis()
-    .then((gitmojis) => prompts(gitmojis))
+    .then((gitmojis) => prompts(gitmojis, mode))
     .then((questions) => {
       inquirer.prompt(questions).then((answers) => {
         if (mode === 'hook') return withHook(answers)

--- a/src/utils/getDefaultCommitContent.js
+++ b/src/utils/getDefaultCommitContent.js
@@ -1,0 +1,41 @@
+// @flow
+import fs from 'fs'
+
+import { type CommitMode } from '../commands/commit'
+
+const COMMIT_FILE_PATH_INDEX = 3
+const COMMIT_TITLE_LINE_INDEX = 0
+const COMMIT_MESSAGE_LINE_INDEX = 2
+
+const getDefaultCommitContent = (
+  mode: CommitMode
+): { title: ?string, message: ?string } => {
+  /*
+    Since the hook is called with `gitmoji --hook $1`
+    According to https://git-scm.com/docs/githooks#_prepare_commit_msg,
+    the commit file path will be stored in the 4th argument of the command
+  */
+  const commitFilePath: string = process.argv[COMMIT_FILE_PATH_INDEX]
+
+  if (mode === 'client' || !fs.existsSync(commitFilePath)) {
+    return {
+      title: null,
+      message: null
+    }
+  }
+
+  const commitFileContent: Array<string> = fs
+    .readFileSync(commitFilePath)
+    .toString()
+    .split('\n')
+
+  return {
+    title: commitFileContent[COMMIT_TITLE_LINE_INDEX],
+    message:
+      commitFileContent.length > COMMIT_MESSAGE_LINE_INDEX
+        ? commitFileContent[COMMIT_MESSAGE_LINE_INDEX]
+        : null
+  }
+}
+
+export default getDefaultCommitContent

--- a/test/commands/__snapshots__/commit.spec.js.snap
+++ b/test/commands/__snapshots__/commit.spec.js.snap
@@ -8,6 +8,62 @@ Object {
 }
 `;
 
+exports[`commit command prompts with default commit content in commit mode should not fill default title and message 1`] = `
+Array [
+  Object {
+    "message": "Choose a gitmoji:",
+    "name": "gitmoji",
+    "source": [Function],
+    "type": "autocomplete",
+  },
+  Object {
+    "message": "Enter the scope of current changes:",
+    "name": "scope",
+    "validate": [Function],
+  },
+  Object {
+    "message": "Enter the commit title",
+    "name": "title",
+    "transformer": [Function],
+    "validate": [Function],
+  },
+  Object {
+    "message": "Enter the commit message:",
+    "name": "message",
+    "validate": [Function],
+  },
+]
+`;
+
+exports[`commit command prompts with default commit content in hook mode should match the default title and message 1`] = `
+Array [
+  Object {
+    "message": "Choose a gitmoji:",
+    "name": "gitmoji",
+    "source": [Function],
+    "type": "autocomplete",
+  },
+  Object {
+    "message": "Enter the scope of current changes:",
+    "name": "scope",
+    "validate": [Function],
+  },
+  Object {
+    "default": "commit title",
+    "message": "Enter the commit title",
+    "name": "title",
+    "transformer": [Function],
+    "validate": [Function],
+  },
+  Object {
+    "default": "commit message",
+    "message": "Enter the commit message:",
+    "name": "message",
+    "validate": [Function],
+  },
+]
+`;
+
 exports[`commit command prompts with scope prompt should match the array of questions 1`] = `
 Array [
   Object {

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -42,3 +42,10 @@ export const clientCommitAnswersWithScope = {
 export const commitResult = 'Commit result'
 
 export const argv = 'commit'
+
+export const emptyDefaultCommitContent = { title: null, message: null }
+
+export const defaultCommitContent = {
+  title: 'commit title',
+  message: 'commit message'
+}

--- a/test/utils/getDefaultCommitContent.spec.js
+++ b/test/utils/getDefaultCommitContent.spec.js
@@ -1,0 +1,40 @@
+import fs from 'fs'
+import getDefaultCommitContent from '../../src/utils/getDefaultCommitContent'
+
+describe('getDefaultCommitContent', () => {
+  describe('when file exists', () => {
+    beforeAll(() => {
+      fs.existsSync.mockImplementation(() => true)
+      fs.readFileSync.mockReturnValueOnce({
+        toString: () => 'commit title\n\ncommit message'
+      })
+    })
+
+    it('should retrieve title and message in hook mode', () => {
+      const { title, message } = getDefaultCommitContent('hook')
+
+      expect(title).toBe('commit title')
+      expect(message).toBe('commit message')
+    })
+
+    it('should retrieve null title and message in client mode', () => {
+      const { title, message } = getDefaultCommitContent('client')
+
+      expect(title).toBe(null)
+      expect(message).toBe(null)
+    })
+  })
+
+  describe('when file does not exist', () => {
+    beforeAll(() => {
+      fs.existsSync.mockImplementation(() => false)
+    })
+
+    it('should retrieve null title and message', () => {
+      const { title, message } = getDefaultCommitContent('hook')
+
+      expect(title).toBe(null)
+      expect(message).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
## Description

Hi @carloscuesta, this PR adds prefilling the `title` and `message` prompts when in `hook` mode.
This allows to keep your titles and messages in your history.

![gitmoji-prefill-hook](https://user-images.githubusercontent.com/19605940/90916131-d42b2c00-e3e0-11ea-8029-c977399b12f7.gif)
