### PR TITLE
Implement hook abord on amend

### DIFF
--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -5,7 +5,7 @@ import getEmojis from '../../utils/getEmojis'
 import prompts from './prompts'
 import withHook, {
   registerHookInterruptionHandler,
-  cancelIfRebasing
+  cancelIfNeeded
 } from './withHook'
 import withClient from './withClient'
 
@@ -14,7 +14,7 @@ export type CommitMode = 'client' | 'hook'
 const commit = (mode: CommitMode) => {
   if (mode === 'hook') {
     registerHookInterruptionHandler()
-    return cancelIfRebasing().then(() => promptAndCommit(mode))
+    return cancelIfNeeded().then(() => promptAndCommit(mode))
   }
 
   return promptAndCommit(mode)

--- a/src/commands/commit/withHook/index.js
+++ b/src/commands/commit/withHook/index.js
@@ -41,4 +41,23 @@ export const cancelIfRebasing = () =>
     }
   )
 
+export const COMMIT_MESSAGE_SOURCE = 4
+
+export const cancelIfAmending = () =>
+  new Promise<void>((resolve) => {
+    /*
+      from https://git-scm.com/docs/githooks#_prepare_commit_msg
+      the commit message source is passed as second argument and corresponding 4 for gitmoji-cli
+      `gitmoji --hook $1 $2`
+    */
+    const commitMessageSource: string = process.argv[COMMIT_MESSAGE_SOURCE]
+    if (commitMessageSource.startsWith('commit')) {
+      process.exit(0)
+    }
+    resolve()
+  })
+
+// I avoid Promise.all to avoid race condition in future cancel callbacks
+export const cancelIfNeeded = () => cancelIfAmending().then(cancelIfRebasing)
+
 export default withHook

--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -4,7 +4,7 @@ const HOOK: Object = {
   PATH: '/hooks/prepare-commit-msg',
   CONTENTS:
     '#!/bin/sh\n# gitmoji as a commit hook\n' +
-    'exec < /dev/tty\ngitmoji --hook $1\n'
+    'exec < /dev/tty\ngitmoji --hook $1 $2\n'
 }
 
 export default HOOK

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -5,7 +5,7 @@ Object {
   "CONTENTS": "#!/bin/sh
 # gitmoji as a commit hook
 exec < /dev/tty
-gitmoji --hook $1
+gitmoji --hook $1 $2
 ",
   "PATH": "/hooks/prepare-commit-msg",
   "PERMISSIONS": 509,

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -11,6 +11,7 @@ import commit from '../../src/commands/commit'
 import guard from '../../src/commands/commit/guard'
 import prompts from '../../src/commands/commit/prompts'
 import * as stubs from './stubs'
+import { COMMIT_MESSAGE_SOURCE } from '../../src/commands/commit/withHook/index'
 
 jest.mock('../../src/utils/getDefaultCommitContent')
 jest.mock('../../src/utils/getEmojis')
@@ -129,6 +130,7 @@ describe('commit command', () => {
         getEmojis.mockResolvedValue(stubs.gitmojis)
         mockProcess.mockProcessExit()
         process.argv[3] = stubs.argv
+        process.argv[COMMIT_MESSAGE_SOURCE] = stubs.commitSource
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent
         )
@@ -158,6 +160,7 @@ describe('commit command', () => {
         getEmojis.mockResolvedValue(stubs.gitmojis)
         mockProcess.mockProcessExit()
         process.argv[3] = stubs.argv
+        process.argv[COMMIT_MESSAGE_SOURCE] = stubs.commitSource
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent
         )
@@ -185,10 +188,33 @@ describe('commit command', () => {
         when the hook mode detect that the user is rebasing. (Simulated to not kill the tests)
         Simulation needed because if we just mock process exit, then the code execution resume in the test.
         */
+        process.argv[COMMIT_MESSAGE_SOURCE] = stubs.commitSource
         mockProcess.mockProcessExit(new Error('ProcessExit0'))
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         // mock that we found one of the rebase trigger (file existence in .git)
         fs.existsSync.mockReturnValueOnce(true)
+
+        try {
+          await commit('hook')
+        } catch (e) {
+          expect(e.message).toMatch('ProcessExit0')
+        }
+
+        expect(process.exit).toHaveBeenCalledWith(0)
+      })
+    })
+
+    describe('when amending', () => {
+      it('should cancel the hook', async () => {
+        /*
+        Use an exception to suspend code execution to simulate the process.exit triggered
+        when the hook mode detect that the user is rebasing. (Simulated to not kill the tests)
+        Simulation needed because if we just mock process exit, then the code execution resume in the test.
+        */
+        mockProcess.mockProcessExit(new Error('ProcessExit0'))
+        execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
+        // mock that we are amending
+        process.argv[COMMIT_MESSAGE_SOURCE] = 'commit sha123'
 
         try {
           await commit('hook')
@@ -224,6 +250,7 @@ describe('commit command', () => {
         // Use an exception to suspend code execution to simulate process.exit
         mockProcess.mockProcessExit(new Error('SIGINT'))
         process.argv[3] = stubs.argv
+        process.argv[COMMIT_MESSAGE_SOURCE] = stubs.commitSource
 
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -42,6 +42,7 @@ export const clientCommitAnswersWithScope = {
 export const commitResult = 'Commit result'
 
 export const argv = 'commit'
+export const commitSource = ''
 
 export const emptyDefaultCommitContent = { title: null, message: null }
 


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
I implemented interruption of the hook on `git commit --amend` while investigation `yarn version` command. I recommand reading the linked issue for a more in depth summary of why `yarn release` is not compatible with gitmoji

<!-- Add issue number that this pull request refers to -->
Issue: linked to https://github.com/carloscuesta/gitmoji-cli/issues/497

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
- I added a test and fixed previous ones

ps: love the migration to github actions :heart: 