### PR TITLE
✨ Implement hook abort on amend

### DIFF
--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -5,7 +5,7 @@ import getEmojis from '../../utils/getEmojis'
 import prompts from './prompts'
 import withHook, {
   registerHookInterruptionHandler,
-  cancelIfRebasing
+  cancelIfNeeded
 } from './withHook'
 import withClient from './withClient'
 
@@ -14,7 +14,7 @@ export type CommitMode = 'client' | 'hook'
 const commit = (mode: CommitMode) => {
   if (mode === 'hook') {
     registerHookInterruptionHandler()
-    return cancelIfRebasing().then(() => promptAndCommit(mode))
+    return cancelIfNeeded().then(() => promptAndCommit(mode))
   }
 
   return promptAndCommit(mode)

--- a/src/commands/commit/withHook/index.js
+++ b/src/commands/commit/withHook/index.js
@@ -41,4 +41,23 @@ export const cancelIfRebasing = () =>
     }
   )
 
+export const COMMIT_MESSAGE_SOURCE = 4
+
+export const cancelIfAmending = () =>
+  new Promise<void>((resolve) => {
+    /*
+      from https://git-scm.com/docs/githooks#_prepare_commit_msg
+      the commit message source is passed as second argument and corresponding 4 for gitmoji-cli
+      `gitmoji --hook $1 $2`
+    */
+    const commitMessageSource: ?string = process.argv[COMMIT_MESSAGE_SOURCE]
+    if (commitMessageSource && commitMessageSource.startsWith('commit')) {
+      process.exit(0)
+    }
+    resolve()
+  })
+
+// I avoid Promise.all to avoid race condition in future cancel callbacks
+export const cancelIfNeeded = () => cancelIfAmending().then(cancelIfRebasing)
+
 export default withHook

--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -4,7 +4,7 @@ const HOOK: Object = {
   PATH: '/hooks/prepare-commit-msg',
   CONTENTS:
     '#!/bin/sh\n# gitmoji as a commit hook\n' +
-    'exec < /dev/tty\ngitmoji --hook $1\n'
+    'exec < /dev/tty\ngitmoji --hook $1 $2\n'
 }
 
 export default HOOK

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -5,7 +5,7 @@ Object {
   "CONTENTS": "#!/bin/sh
 # gitmoji as a commit hook
 exec < /dev/tty
-gitmoji --hook $1
+gitmoji --hook $1 $2
 ",
   "PATH": "/hooks/prepare-commit-msg",
   "PERMISSIONS": 509,

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -42,6 +42,7 @@ export const clientCommitAnswersWithScope = {
 export const commitResult = 'Commit result'
 
 export const argv = 'commit'
+export const commitSource = ''
 
 export const emptyDefaultCommitContent = { title: null, message: null }
 


### PR DESCRIPTION


## Description
This reverts commit caf87bd5fbcdbac21b76ab06f58557811abb5469 (re-implement abord on amend) and
implement a fix for missing second hook param.

<!-- Explanation about your pull request, what changes you've made -->

<!-- Add issue number that this pull request refers to -->
Issue: https://github.com/carloscuesta/gitmoji-cli/issues/509

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
- I added a test for undefined
