### PR TITLE
✨ (feat): Added environment variable support 🥓

### DIFF
--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -9,7 +9,8 @@ import { type Answers } from '../prompts'
 
 const withClient = async (answers: Answers) => {
   try {
-    const scope = answers.scope ? `(${answers.scope}): ` : ''
+    let scope = process.env.SCOPE || answers.scope
+    scope = scope ? `(${scope}): ` : ''
     const title = `${answers.gitmoji} ${scope}${answers.title}`
     const isSigned = configurationVault.getSignedCommit() ? ['-S'] : []
 

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -9,8 +9,11 @@ import { type Answers } from '../prompts'
 
 const withClient = async (answers: Answers) => {
   try {
-    let scope = process.env.SCOPE || answers.scope
-    scope = scope ? `(${scope}): ` : ''
+    const scope = process.env.SCOPE
+      ? process.env.SCOPE
+      : answers.scope
+      ? `(${answers.scope}): `
+      : ''
     const title = `${answers.gitmoji} ${scope}${answers.title}`
     const isSigned = configurationVault.getSignedCommit() ? ['-S'] : []
 

--- a/src/utils/configurationVault.js
+++ b/src/utils/configurationVault.js
@@ -36,11 +36,19 @@ const getEmojiFormat = (): string => {
 }
 
 const getSignedCommit = (): boolean => {
-  return config.get(CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT) || false
+  return (
+    process.env.SIGNED_COMMIT ||
+    config.get(CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT) ||
+    false
+  )
 }
 
 const getScopePrompt = (): boolean => {
-  return config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT) || false
+  return (
+    process.env.SCOPE_PROMPT ||
+    config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT) ||
+    false
+  )
 }
 
 export default {

--- a/src/utils/configurationVault.js
+++ b/src/utils/configurationVault.js
@@ -37,7 +37,7 @@ const getEmojiFormat = (): string => {
 
 const getSignedCommit = (): boolean => {
   return (
-    process.env.SIGNED_COMMIT ||
+    !!process.env.SIGNED_COMMIT ||
     config.get(CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT) ||
     false
   )
@@ -45,7 +45,7 @@ const getSignedCommit = (): boolean => {
 
 const getScopePrompt = (): boolean => {
   return (
-    process.env.SCOPE_PROMPT ||
+    !!process.env.SCOPE_PROMPT ||
     config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT) ||
     false
   )


### PR DESCRIPTION
## Description

I just quickly tweak some code to make a few environment variables available. The reason that I made this tweak because I won't be able to use hook on my projects otherwise it will overwrite other hook like husky. In my opinion, adding these as an option will increase flexibility and allow more people to use this awesome tool. (I'm open to suggestions in case I missed some point 😉)

### Added Environment Variables
- **SCOPE_PROMPT** (`boolean`): behave same as the **Scope prompt** option in config
- **SCOPE** (`string`): assign _scope_ directly and skip **Scope prompt**
- **SIGNED_COMMIT** (`boolean`): behave same as the **Signed commits** option in config except that this one enable per commit

Example:
<img width="597" alt="Screen Shot 2021-01-04 at 02 28 07" src="https://user-images.githubusercontent.com/42465929/103487415-cded9780-4e37-11eb-846e-15c20a15f9cd.png">


<!-- Add issue number that this pull request refers to -->
Issue: #465 

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
