### PR TITLE
Add support to skip prompting filled info

### DIFF
--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -16,6 +16,9 @@ const config = () => {
     configurationVault.setScopePrompt(
       answers[CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT]
     )
+    configurationVault.setSkipPromptingFilledInfo(
+      answers[CONFIGURATION_PROMPT_NAMES.SKIP_PROMPTING_FILLED_INFO]
+    )
   })
 }
 

--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -5,7 +5,8 @@ export const CONFIGURATION_PROMPT_NAMES = {
   AUTO_ADD: 'autoAdd',
   EMOJI_FORMAT: 'emojiFormat',
   SCOPE_PROMPT: 'scopePrompt',
-  SIGNED_COMMIT: 'signedCommit'
+  SIGNED_COMMIT: 'signedCommit',
+  SKIP_PROMPTING_FILLED_INFO: 'skipPromptingFilledInfo'
 }
 
 export const EMOJI_COMMIT_FORMATS = {
@@ -41,5 +42,11 @@ export default () => [
     message: 'Enable scope prompt',
     type: 'confirm',
     default: configurationVault.getScopePrompt()
+  },
+  {
+    name: CONFIGURATION_PROMPT_NAMES.SKIP_PROMPTING_FILLED_INFO,
+    message: 'Skip prompting already filled info',
+    type: 'confirm',
+    default: configurationVault.getSkipPromptingFilledInfo()
   }
 ]

--- a/src/utils/configurationVault.js
+++ b/src/utils/configurationVault.js
@@ -24,6 +24,13 @@ const setScopePrompt = (scopePrompt: boolean) => {
   config.set(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT, scopePrompt)
 }
 
+const setSkipPromptingFilledInfo = (skipPromptingFilledInfo: boolean) => {
+  config.set(
+    CONFIGURATION_PROMPT_NAMES.SKIP_PROMPTING_FILLED_INFO,
+    skipPromptingFilledInfo
+  )
+}
+
 const getAutoAdd = (): boolean => {
   return config.get(CONFIGURATION_PROMPT_NAMES.AUTO_ADD) || false
 }
@@ -43,13 +50,21 @@ const getScopePrompt = (): boolean => {
   return config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT) || false
 }
 
+const getSkipPromptingFilledInfo = (): boolean => {
+  return (
+    config.get(CONFIGURATION_PROMPT_NAMES.SKIP_PROMPTING_FILLED_INFO) || false
+  )
+}
+
 export default {
   getAutoAdd,
   getEmojiFormat,
   getScopePrompt,
   getSignedCommit,
+  getSkipPromptingFilledInfo,
   setAutoAdd,
   setEmojiFormat,
   setScopePrompt,
-  setSignedCommit
+  setSignedCommit,
+  setSkipPromptingFilledInfo
 }

--- a/src/utils/getDefaultAnswers.js
+++ b/src/utils/getDefaultAnswers.js
@@ -1,0 +1,27 @@
+import { CommitContent } from './getDefaultCommitContent'
+import type { Answers } from '../commands/commit/prompts'
+import configurationVault from './configurationVault'
+import guard from '../commands/commit/guard'
+
+const getDefaultAnswers = ({
+  gitmoji,
+  title,
+  message
+}: CommitContent): $Shape<Answers> => {
+  const answers: $Shape<Answers> = {}
+  if (!configurationVault.getSkipPromptingFilledInfo()) return answers
+
+  if (gitmoji) {
+    answers.gitmoji = gitmoji
+  }
+  if (title && guard.title(title) === true) {
+    answers.title = title
+  }
+  if (message && guard.message(message) === true) {
+    answers.message = message
+  }
+
+  return answers
+}
+
+export default getDefaultAnswers

--- a/src/utils/getDefaultCommitContent.js
+++ b/src/utils/getDefaultCommitContent.js
@@ -2,14 +2,23 @@
 import fs from 'fs'
 
 import { type CommitMode } from '../commands/commit'
+import configurationVault from './configurationVault'
+import { EMOJI_COMMIT_FORMATS } from '../commands/config/prompts'
 
 const COMMIT_FILE_PATH_INDEX = 3
 const COMMIT_TITLE_LINE_INDEX = 0
 const COMMIT_MESSAGE_LINE_INDEX = 2
 
-const getDefaultCommitContent = (
-  mode: CommitMode
-): { title: ?string, message: ?string } => {
+const gitmojiSymbolRegex = /^(\p{Emoji_Presentation})\s*(.*)/gu
+const gitmojiCodeRegex = /^(:[a-zA-Z_]+:)\s*(.*)/gu
+
+export type CommitContent = {
+  gitmoji: ?string,
+  title: ?string,
+  message: ?string
+}
+
+const getDefaultCommitContent = (mode: CommitMode): CommitContent => {
   /*
     Since the hook is called with `gitmoji --hook $1`
     According to https://git-scm.com/docs/githooks#_prepare_commit_msg,
@@ -19,6 +28,7 @@ const getDefaultCommitContent = (
 
   if (mode === 'client' || !fs.existsSync(commitFilePath)) {
     return {
+      gitmoji: null,
       title: null,
       message: null
     }
@@ -29,8 +39,20 @@ const getDefaultCommitContent = (
     .toString()
     .split('\n')
 
+  let gitmoji = null
+  let title = commitFileContent[COMMIT_TITLE_LINE_INDEX]
+
+  const gitmojiRegexResult =
+    configurationVault.getEmojiFormat() === EMOJI_COMMIT_FORMATS.CODE
+      ? gitmojiCodeRegex.exec(title)
+      : gitmojiSymbolRegex.exec(title)
+  if (gitmojiRegexResult && gitmojiRegexResult.length === 3) {
+    ;[, gitmoji, title] = gitmojiRegexResult
+  }
+
   return {
-    title: commitFileContent[COMMIT_TITLE_LINE_INDEX],
+    gitmoji,
+    title,
     message:
       commitFileContent.length > COMMIT_MESSAGE_LINE_INDEX
         ? commitFileContent[COMMIT_MESSAGE_LINE_INDEX]

--- a/test/commands/__snapshots__/commit.spec.js.snap
+++ b/test/commands/__snapshots__/commit.spec.js.snap
@@ -8,63 +8,44 @@ Object {
 }
 `;
 
-exports[`commit command prompts with default commit content in commit mode should not fill default title and message 1`] = `
+exports[`commit command prompts with scope prompt should ask unanswered questions 1`] = `
 Array [
-  Object {
-    "message": "Choose a gitmoji:",
-    "name": "gitmoji",
-    "source": [Function],
-    "type": "autocomplete",
-  },
   Object {
     "message": "Enter the scope of current changes:",
     "name": "scope",
-    "validate": [Function],
-  },
-  Object {
-    "message": "Enter the commit title",
-    "name": "title",
-    "transformer": [Function],
-    "validate": [Function],
-  },
-  Object {
-    "message": "Enter the commit message:",
-    "name": "message",
-    "validate": [Function],
-  },
-]
-`;
-
-exports[`commit command prompts with default commit content in hook mode should match the default title and message 1`] = `
-Array [
-  Object {
-    "message": "Choose a gitmoji:",
-    "name": "gitmoji",
-    "source": [Function],
-    "type": "autocomplete",
-  },
-  Object {
-    "message": "Enter the scope of current changes:",
-    "name": "scope",
-    "validate": [Function],
-  },
-  Object {
-    "default": "commit title",
-    "message": "Enter the commit title",
-    "name": "title",
-    "transformer": [Function],
-    "validate": [Function],
-  },
-  Object {
-    "default": "commit message",
-    "message": "Enter the commit message:",
-    "name": "message",
     "validate": [Function],
   },
 ]
 `;
 
 exports[`commit command prompts with scope prompt should match the array of questions 1`] = `
+Array [
+  Object {
+    "message": "Choose a gitmoji:",
+    "name": "gitmoji",
+    "source": [Function],
+    "type": "autocomplete",
+  },
+  Object {
+    "message": "Enter the scope of current changes:",
+    "name": "scope",
+    "validate": [Function],
+  },
+  Object {
+    "message": "Enter the commit title",
+    "name": "title",
+    "transformer": [Function],
+    "validate": [Function],
+  },
+  Object {
+    "message": "Enter the commit message:",
+    "name": "message",
+    "validate": [Function],
+  },
+]
+`;
+
+exports[`commit command prompts with scope prompt should not fill default title and message 1`] = `
 Array [
   Object {
     "message": "Choose a gitmoji:",
@@ -106,6 +87,30 @@ Array [
     "validate": [Function],
   },
   Object {
+    "message": "Enter the commit message:",
+    "name": "message",
+    "validate": [Function],
+  },
+]
+`;
+
+exports[`commit command prompts without scope prompt should match the default title and message 1`] = `
+Array [
+  Object {
+    "message": "Choose a gitmoji:",
+    "name": "gitmoji",
+    "source": [Function],
+    "type": "autocomplete",
+  },
+  Object {
+    "default": "commit title",
+    "message": "Enter the commit title",
+    "name": "title",
+    "transformer": [Function],
+    "validate": [Function],
+  },
+  Object {
+    "default": "commit message",
     "message": "Enter the commit message:",
     "name": "message",
     "validate": [Function],

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -124,7 +124,7 @@ describe('commit command', () => {
 
   describe('withHook', () => {
     describe('without scope', () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         console.log = jest.fn()
         inquirer.prompt.mockReturnValue(
           Promise.resolve(stubs.clientCommitAnswers)
@@ -138,7 +138,7 @@ describe('commit command', () => {
         )
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         fs.existsSync.mockReturnValueOnce(false).mockReturnValueOnce(false)
-        commit('hook')
+        await commit('hook')
       })
 
       it('should commit using the hook', () => {
@@ -154,7 +154,7 @@ describe('commit command', () => {
     })
 
     describe('with scope', () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         console.log = jest.fn()
         inquirer.prompt.mockReturnValue(
           Promise.resolve(stubs.clientCommitAnswersWithScope)
@@ -168,7 +168,7 @@ describe('commit command', () => {
         )
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         fs.existsSync.mockReturnValueOnce(false).mockReturnValueOnce(false)
-        commit('hook')
+        await commit('hook')
       })
 
       it('should commit using the hook', () => {

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -1,6 +1,7 @@
 import inquirer from 'inquirer'
 import execa from 'execa'
 import fs from 'fs'
+
 const mockProcess = require('jest-mock-process')
 
 import configurationVault from '../../src/utils/configurationVault'
@@ -12,6 +13,7 @@ import guard from '../../src/commands/commit/guard'
 import prompts from '../../src/commands/commit/prompts'
 import * as stubs from './stubs'
 import { COMMIT_MESSAGE_SOURCE } from '../../src/commands/commit/withHook/index'
+import type { Answers } from '../../src/commands/commit/prompts'
 
 jest.mock('../../src/utils/getDefaultCommitContent')
 jest.mock('../../src/utils/getEmojis')
@@ -332,48 +334,73 @@ describe('commit command', () => {
 
     describe('without scope prompt', () => {
       beforeAll(() => {
-        getDefaultCommitContent.mockReturnValueOnce(
-          stubs.emptyDefaultCommitContent
-        )
+        configurationVault.getScopePrompt.mockReturnValue(false)
       })
 
       it('should match the array of questions', () => {
-        expect(prompts(stubs.gitmojis, 'client')).toMatchSnapshot()
+        expect(
+          prompts(
+            stubs.gitmojis,
+            stubs.emptyDefaultCommitContent,
+            stubs.emptyDefaultAnswers
+          )
+        ).toMatchSnapshot()
+      })
+
+      it('should match the default title and message', () => {
+        expect(
+          prompts(
+            stubs.gitmojis,
+            stubs.defaultCommitContent,
+            stubs.emptyDefaultAnswers
+          )
+        ).toMatchSnapshot()
+      })
+
+      it('should ask unanswered questions', () => {
+        const defaultAnswers: $Shape<Answers> = {
+          gitmoji: ':sparkles:',
+          ...stubs.defaultCommitContent
+        }
+        expect(
+          prompts(stubs.gitmojis, stubs.defaultCommitContent, defaultAnswers)
+        ).toEqual([])
       })
     })
 
     describe('with scope prompt', () => {
       beforeAll(() => {
-        getDefaultCommitContent.mockReturnValueOnce(
-          stubs.emptyDefaultCommitContent
-        )
         configurationVault.getScopePrompt.mockReturnValue(true)
       })
 
       it('should match the array of questions', () => {
-        expect(prompts(stubs.gitmojis, 'client')).toMatchSnapshot()
-      })
-    })
-
-    describe('with default commit content in hook mode', () => {
-      beforeAll(() => {
-        getDefaultCommitContent.mockReturnValueOnce(stubs.defaultCommitContent)
-      })
-
-      it('should match the default title and message', () => {
-        expect(prompts(stubs.gitmojis, 'hook')).toMatchSnapshot()
-      })
-    })
-
-    describe('with default commit content in commit mode', () => {
-      beforeAll(() => {
-        getDefaultCommitContent.mockReturnValueOnce(
-          stubs.emptyDefaultCommitContent
-        )
+        expect(
+          prompts(
+            stubs.gitmojis,
+            stubs.emptyDefaultCommitContent,
+            stubs.emptyDefaultAnswers
+          )
+        ).toMatchSnapshot()
       })
 
       it('should not fill default title and message', () => {
-        expect(prompts(stubs.gitmojis, 'commit')).toMatchSnapshot()
+        expect(
+          prompts(
+            stubs.gitmojis,
+            stubs.emptyDefaultCommitContent,
+            stubs.emptyDefaultAnswers
+          )
+        ).toMatchSnapshot()
+      })
+
+      it('should ask unanswered questions', () => {
+        const defaultAnswers: $Shape<Answers> = {
+          gitmoji: ':sparkles:',
+          ...stubs.defaultCommitContent
+        }
+        expect(
+          prompts(stubs.gitmojis, stubs.defaultCommitContent, defaultAnswers)
+        ).toMatchSnapshot()
       })
     })
   })

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -50,3 +50,5 @@ export const defaultCommitContent = {
   title: 'commit title',
   message: 'commit message'
 }
+
+export const emptyDefaultAnswers = {}

--- a/test/utils/__snapshots__/configurationVault.spec.js.snap
+++ b/test/utils/__snapshots__/configurationVault.spec.js.snap
@@ -6,9 +6,11 @@ Object {
   "getEmojiFormat": [Function],
   "getScopePrompt": [Function],
   "getSignedCommit": [Function],
+  "getSkipPromptingFilledInfo": [Function],
   "setAutoAdd": [Function],
   "setEmojiFormat": [Function],
   "setScopePrompt": [Function],
   "setSignedCommit": [Function],
+  "setSkipPromptingFilledInfo": [Function],
 }
 `;

--- a/test/utils/configurationVault.spec.js
+++ b/test/utils/configurationVault.spec.js
@@ -29,6 +29,10 @@ describe('configurationVault', () => {
     it('should return the default value for scopePrompt', () => {
       expect(configurationVault.getScopePrompt()).toEqual(false)
     })
+
+    it('should return the default value for skipPromptingFilledInfo', () => {
+      expect(configurationVault.getSkipPromptingFilledInfo()).toEqual(false)
+    })
   })
 
   describe('setter and getters', () => {
@@ -90,6 +94,19 @@ describe('configurationVault', () => {
       )
       expect(config.get).toHaveBeenCalledWith(
         CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT
+      )
+    })
+
+    it('should set and return value for skipPromptingFilledInfo', () => {
+      configurationVault.setSkipPromptingFilledInfo(true)
+      configurationVault.getSkipPromptingFilledInfo()
+
+      expect(config.set).toHaveBeenCalledWith(
+        CONFIGURATION_PROMPT_NAMES.SKIP_PROMPTING_FILLED_INFO,
+        true
+      )
+      expect(config.get).toHaveBeenCalledWith(
+        CONFIGURATION_PROMPT_NAMES.SKIP_PROMPTING_FILLED_INFO
       )
     })
   })

--- a/test/utils/getDefaultAnswers.spec.js
+++ b/test/utils/getDefaultAnswers.spec.js
@@ -1,0 +1,48 @@
+import configurationVault from '../../src/utils/configurationVault'
+import getDefaultAnswers from '../../src/utils/getDefaultAnswers'
+import * as stubs from './stubs'
+
+jest.mock('../../src/utils/configurationVault')
+
+describe('getDefaultAnswers', () => {
+  describe('when skip prompting is disabled', () => {
+    beforeAll(() => {
+      configurationVault.getSkipPromptingFilledInfo.mockReturnValue(false)
+    })
+
+    it('should return empty default answers', () => {
+      expect(getDefaultAnswers(stubs.commitContent)).toEqual({})
+    })
+  })
+
+  describe('when skip prompting is enabled', () => {
+    beforeAll(() => {
+      configurationVault.getSkipPromptingFilledInfo.mockReturnValue(true)
+    })
+
+    it('should return empty default answers', () => {
+      expect(getDefaultAnswers({})).toEqual({})
+    })
+
+    it('should return all valid answers', () => {
+      expect(getDefaultAnswers(stubs.commitContent)).toMatchInlineSnapshot(`
+        Object {
+          "gitmoji": ":sparkles:",
+          "message": "commit message",
+          "title": "commit title",
+        }
+      `)
+      expect(
+        getDefaultAnswers({
+          ...stubs.commitContent,
+          message: '` broken message'
+        })
+      ).toMatchInlineSnapshot(`
+        Object {
+          "gitmoji": ":sparkles:",
+          "title": "commit title",
+        }
+      `)
+    })
+  })
+})

--- a/test/utils/getDefaultCommitContent.spec.js
+++ b/test/utils/getDefaultCommitContent.spec.js
@@ -1,27 +1,67 @@
 import fs from 'fs'
 import getDefaultCommitContent from '../../src/utils/getDefaultCommitContent'
+import configurationVault from '../../src/utils/configurationVault'
+import { EMOJI_COMMIT_FORMATS } from '../../src/commands/config/prompts'
+
+jest.mock('../../src/utils/configurationVault')
 
 describe('getDefaultCommitContent', () => {
   describe('when file exists', () => {
     beforeAll(() => {
       fs.existsSync.mockImplementation(() => true)
-      fs.readFileSync.mockReturnValueOnce({
-        toString: () => 'commit title\n\ncommit message'
+    })
+
+    describe('without gitmoji on the title', () => {
+      beforeAll(() => {
+        fs.readFileSync.mockReturnValueOnce({
+          toString: () => 'commit title\n\ncommit message'
+        })
+      })
+
+      it('should retrieve gitmoji, title and message in hook mode', () => {
+        const { title, message } = getDefaultCommitContent('hook')
+
+        expect(title).toBe('commit title')
+        expect(message).toBe('commit message')
+      })
+
+      it('should retrieve null title and message in client mode', () => {
+        const { gitmoji, title, message } = getDefaultCommitContent('client')
+
+        expect(gitmoji).toBe(null)
+        expect(title).toBe(null)
+        expect(message).toBe(null)
       })
     })
 
-    it('should retrieve title and message in hook mode', () => {
-      const { title, message } = getDefaultCommitContent('hook')
+    describe('with gitmoji', () => {
+      it('should retrieve code gitmoji, title and message', () => {
+        configurationVault.getEmojiFormat.mockReturnValue(
+          EMOJI_COMMIT_FORMATS.CODE
+        )
+        fs.readFileSync.mockReturnValueOnce({
+          toString: () => ':sparkles: commit title\n\ncommit message'
+        })
+        const { gitmoji, title, message } = getDefaultCommitContent('hook')
 
-      expect(title).toBe('commit title')
-      expect(message).toBe('commit message')
-    })
+        expect(gitmoji).toBe(':sparkles:')
+        expect(title).toBe('commit title')
+        expect(message).toBe('commit message')
+      })
 
-    it('should retrieve null title and message in client mode', () => {
-      const { title, message } = getDefaultCommitContent('client')
+      it('should retrieve symbol gitmoji, title and message', () => {
+        configurationVault.getEmojiFormat.mockReturnValue(
+          EMOJI_COMMIT_FORMATS.EMOJI
+        )
+        fs.readFileSync.mockReturnValueOnce({
+          toString: () => '✨ commit title\n\ncommit message'
+        })
+        const { gitmoji, title, message } = getDefaultCommitContent('hook')
 
-      expect(title).toBe(null)
-      expect(message).toBe(null)
+        expect(gitmoji).toBe('✨')
+        expect(title).toBe('commit title')
+        expect(message).toBe('commit message')
+      })
     })
   })
 

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -409,3 +409,9 @@ export const gitmojisResponse = {
 }
 
 export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'
+
+export const commitContent = Object.freeze({
+  gitmoji: ':sparkles:',
+  title: 'commit title',
+  message: 'commit message'
+})


### PR DESCRIPTION
## Description

Add support to an option that will skip asking `gitmoji`/`title`/`message` when they are filled.

<!-- Add issue number that this pull request refers to -->
Issue: #534 

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
