### PR TITLE
:sparkles: update hooks create & delete path

### DIFF
--- a/src/commands/hook/create/index.js
+++ b/src/commands/hook/create/index.js
@@ -11,15 +11,8 @@ const createHook = async () => {
   try {
     const hookFile = await getAbsoluteHooksPath(HOOK.FILENAME)
 
-    fs.writeFile(
-      hookFile,
-      HOOK.CONTENTS,
-      { mode: HOOK.PERMISSIONS },
-      (error) => {
-        if (error) return spinner.fail(error)
-        spinner.succeed('Gitmoji commit hook created successfully')
-      }
-    )
+    fs.writeFileSync(hookFile, HOOK.CONTENTS, { mode: HOOK.PERMISSIONS })
+    spinner.succeed('Gitmoji commit hook created successfully')
   } catch (error) {
     spinner.fail(`Error: ${error}`)
   }

--- a/src/commands/hook/create/index.js
+++ b/src/commands/hook/create/index.js
@@ -1,28 +1,15 @@
 // @flow
 import fs from 'fs'
-import execa from 'execa'
 import ora from 'ora'
-import path from 'path'
 
 import HOOK from '../hook'
+import getAbsoluteHooksPath from '../../../utils/getAbsoluteHooksPath'
 
-/**
- * Create a "prepare-commit-msg" git hook
- *
- * If "core.hooksPath" is not set in git config, use default ".git/hooks"
- * @see https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
- */
 const createHook = async () => {
   const spinner = ora('Creating the gitmoji commit hook').start()
 
   try {
-    const { stdout } = await execa('git', ['config', '--get', 'core.hooksPath'])
-    const relativeHooksPath = stdout || '.git/hooks'
-    const hookFile = path.resolve(
-      process.cwd(),
-      relativeHooksPath,
-      HOOK.FILENAME
-    )
+    const hookFile = await getAbsoluteHooksPath(HOOK.FILENAME)
 
     fs.writeFile(
       hookFile,

--- a/src/commands/hook/create/index.js
+++ b/src/commands/hook/create/index.js
@@ -2,17 +2,30 @@
 import fs from 'fs'
 import execa from 'execa'
 import ora from 'ora'
+import path from 'path'
 
 import HOOK from '../hook'
 
+/**
+ * Create a "prepare-commit-msg" git hook
+ *
+ * If "core.hooksPath" is not set in git config, use default ".git/hooks"
+ * @see https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+ */
 const createHook = async () => {
   const spinner = ora('Creating the gitmoji commit hook').start()
 
   try {
-    const { stdout } = await execa('git', ['rev-parse', '--absolute-git-dir'])
+    const { stdout } = await execa('git', ['config', '--get', 'core.hooksPath'])
+    const relativeHooksPath = stdout || '.git/hooks'
+    const hookFile = path.resolve(
+      process.cwd(),
+      relativeHooksPath,
+      HOOK.FILENAME
+    )
 
     fs.writeFile(
-      stdout + HOOK.PATH,
+      hookFile,
       HOOK.CONTENTS,
       { mode: HOOK.PERMISSIONS },
       (error) => {

--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -1,7 +1,7 @@
 // @flow
 const HOOK: Object = {
   PERMISSIONS: 0o775,
-  PATH: '/hooks/prepare-commit-msg',
+  FILENAME: 'prepare-commit-msg',
   CONTENTS:
     '#!/bin/sh\n# gitmoji as a commit hook\n' +
     'exec < /dev/tty\ngitmoji --hook $1 $2\n'

--- a/src/commands/hook/remove/index.js
+++ b/src/commands/hook/remove/index.js
@@ -11,13 +11,10 @@ const removeHook = async () => {
   try {
     const hookFile = await getAbsoluteHooksPath(HOOK.FILENAME)
 
-    fs.unlink(hookFile, (error) => {
-      if (error)
-        return spinner.fail('Error: Gitmoji commit hook is not created')
-      spinner.succeed('Gitmoji commit hook removed successfully')
-    })
+    fs.unlinkSync(hookFile)
+    spinner.succeed('Gitmoji commit hook removed successfully')
   } catch (error) {
-    spinner.fail(`Error: ${error}`)
+    spinner.fail('Error: Gitmoji commit hook is not created')
   }
 }
 

--- a/src/commands/hook/remove/index.js
+++ b/src/commands/hook/remove/index.js
@@ -1,28 +1,15 @@
 // @flow
 import fs from 'fs'
-import execa from 'execa'
 import ora from 'ora'
-import path from 'path'
 
 import HOOK from '../hook'
+import getAbsoluteHooksPath from '../../../utils/getAbsoluteHooksPath'
 
-/**
- * Delete a "prepare-commit-msg" git hook
- *
- * If "core.hooksPath" is not set in git config, use default ".git/hooks"
- * @see https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
- */
 const removeHook = async () => {
   const spinner = ora('Creating the gitmoji commit hook').start()
 
   try {
-    const { stdout } = await execa('git', ['config', '--get', 'core.hooksPath'])
-    const relativeHooksPath = stdout || '.git/hooks'
-    const hookFile = path.resolve(
-      process.cwd(),
-      relativeHooksPath,
-      HOOK.FILENAME
-    )
+    const hookFile = await getAbsoluteHooksPath(HOOK.FILENAME)
 
     fs.unlink(hookFile, (error) => {
       if (error)

--- a/src/commands/hook/remove/index.js
+++ b/src/commands/hook/remove/index.js
@@ -2,16 +2,29 @@
 import fs from 'fs'
 import execa from 'execa'
 import ora from 'ora'
+import path from 'path'
 
 import HOOK from '../hook'
 
+/**
+ * Delete a "prepare-commit-msg" git hook
+ *
+ * If "core.hooksPath" is not set in git config, use default ".git/hooks"
+ * @see https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+ */
 const removeHook = async () => {
   const spinner = ora('Creating the gitmoji commit hook').start()
 
   try {
-    const { stdout } = await execa('git', ['rev-parse', '--absolute-git-dir'])
+    const { stdout } = await execa('git', ['config', '--get', 'core.hooksPath'])
+    const relativeHooksPath = stdout || '.git/hooks'
+    const hookFile = path.resolve(
+      process.cwd(),
+      relativeHooksPath,
+      HOOK.FILENAME
+    )
 
-    fs.unlink(stdout + HOOK.PATH, (error) => {
+    fs.unlink(hookFile, (error) => {
       if (error)
         return spinner.fail('Error: Gitmoji commit hook is not created')
       spinner.succeed('Gitmoji commit hook removed successfully')

--- a/src/utils/getAbsoluteHooksPath.js
+++ b/src/utils/getAbsoluteHooksPath.js
@@ -2,39 +2,21 @@
 import execa from 'execa'
 import path from 'path'
 
-const getAbsoluteHooksPath = async (hookName: string) => {
-  let absoluteHooksPath
-
-  // First retrieve the hooks path from the git config
-  // It can be either absolute or relative according to git documentation
-  // NOTE: this requires git >= 2.9 (2016-06-13)
-  const hooksPathCommand = await execa('git', [
+const getAbsoluteHooksPath = async (hookName: string): Promise<string> => {
+  const { stdout: coreHooksPath } = await execa('git', [
     'config',
     '--get',
     'core.hooksPath'
   ])
-  const hooksPath = hooksPathCommand.stdout || '.git/hooks'
 
-  if (path.isAbsolute(hooksPath)) {
-    // If the hooks path is absolute, return it
-    absoluteHooksPath = hooksPathCommand.stdout
-  } else {
-    // If it is relative, retrieve the absolute path of the git directory then map the relative hooks path to it
-    // NOTE: this requires git >= 2.13 (2017-05-10)
-    const absoluteGitDirCommand = await execa('git', [
-      'rev-parse',
-      '--absolute-git-dir'
-    ])
+  const { stdout: gitDirPath } = await execa('git', [
+    'rev-parse',
+    '--absolute-git-dir'
+  ])
 
-    // Finally, reassemble those paths
-    absoluteHooksPath = path.resolve(
-      // Use dirname to remove the trailing "/.git" from the path
-      path.dirname(absoluteGitDirCommand.stdout),
-      hooksPath
-    )
-  }
+  const hooksPath = coreHooksPath || gitDirPath + '/hooks'
 
-  return path.resolve(absoluteHooksPath, hookName)
+  return path.resolve(hooksPath, hookName)
 }
 
 export default getAbsoluteHooksPath

--- a/src/utils/getAbsoluteHooksPath.js
+++ b/src/utils/getAbsoluteHooksPath.js
@@ -1,0 +1,40 @@
+// @flow
+import execa from 'execa'
+import path from 'path'
+
+const getAbsoluteHooksPath = async (hookName: string) => {
+  let absoluteHooksPath
+
+  // First retrieve the hooks path from the git config
+  // It can be either absolute or relative according to git documentation
+  // NOTE: this requires git >= 2.9 (2016-06-13)
+  const hooksPathCommand = await execa('git', [
+    'config',
+    '--get',
+    'core.hooksPath'
+  ])
+  const hooksPath = hooksPathCommand.stdout || '.git/hooks'
+
+  if (path.isAbsolute(hooksPath)) {
+    // If the hooks path is absolute, return it
+    absoluteHooksPath = hooksPathCommand.stdout
+  } else {
+    // If it is relative, retrieve the absolute path of the git directory then map the relative hooks path to it
+    // NOTE: this requires git >= 2.13 (2017-05-10)
+    const absoluteGitDirCommand = await execa('git', [
+      'rev-parse',
+      '--absolute-git-dir'
+    ])
+
+    // Finally, reassemble those paths
+    absoluteHooksPath = path.resolve(
+      // Use dirname to remove the trailing "/.git" from the path
+      path.dirname(absoluteGitDirCommand.stdout),
+      hooksPath
+    )
+  }
+
+  return path.resolve(absoluteHooksPath, hookName)
+}
+
+export default getAbsoluteHooksPath

--- a/src/utils/isHookCreated.js
+++ b/src/utils/isHookCreated.js
@@ -1,13 +1,14 @@
 // @flow
 import execa from 'execa'
 import fs from 'fs'
+import path from 'path'
 
 import HOOK from '../commands/hook/hook'
 
 const isHookCreated = async () => {
   try {
-    const { stdout } = await execa('git', ['rev-parse', '--absolute-git-dir'])
-    const hookFile = stdout + HOOK.PATH
+    const { stdout } = await execa('git', ['config', '--get', 'core.hooksPath'])
+    const hookFile = path.resolve(process.cwd(), stdout, HOOK.FILENAME)
 
     if (fs.existsSync(hookFile)) {
       return fs.readFileSync(hookFile, { encoding: 'utf-8' }) === HOOK.CONTENTS

--- a/src/utils/isHookCreated.js
+++ b/src/utils/isHookCreated.js
@@ -1,14 +1,12 @@
 // @flow
-import execa from 'execa'
 import fs from 'fs'
-import path from 'path'
 
 import HOOK from '../commands/hook/hook'
+import getAbsoluteHooksPath from './getAbsoluteHooksPath'
 
 const isHookCreated = async () => {
   try {
-    const { stdout } = await execa('git', ['config', '--get', 'core.hooksPath'])
-    const hookFile = path.resolve(process.cwd(), stdout, HOOK.FILENAME)
+    const hookFile = await getAbsoluteHooksPath(HOOK.FILENAME)
 
     if (fs.existsSync(hookFile)) {
       return fs.readFileSync(hookFile, { encoding: 'utf-8' }) === HOOK.CONTENTS

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -7,7 +7,7 @@ Object {
 exec < /dev/tty
 gitmoji --hook $1 $2
 ",
-  "PATH": "/hooks/prepare-commit-msg",
+  "FILENAME": "prepare-commit-msg",
   "PERMISSIONS": 509,
 }
 `;

--- a/test/commands/hook.spec.js
+++ b/test/commands/hook.spec.js
@@ -16,23 +16,27 @@ describe('hook command', () => {
   })
 
   describe('create hook', () => {
-    beforeAll(() => {
-      execa.mockReturnValue({ stdout: stubs.coreHooksPath })
-      hook.create()
+    beforeEach(() => {
+      execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
+      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
     })
 
-    it('should obtain the hooks dir path with execa', () => {
+    it('should create the hook file', async () => {
+      await hook.create()
+
       expect(execa).toHaveBeenCalledWith('git', [
         'config',
         '--get',
         'core.hooksPath'
       ])
-    })
+      expect(execa).toHaveBeenCalledWith('git', [
+        'rev-parse',
+        '--absolute-git-dir'
+      ])
 
-    it('should create the hook file', () => {
       const hookFile = path.resolve(
-        process.cwd(),
-        stubs.coreHooksPath,
+        path.dirname(stubs.gitAbsoluteDir),
+        stubs.relativeCoreHooksPath,
         hookConfig.FILENAME
       )
       expect(fs.writeFile).toHaveBeenCalledWith(
@@ -45,23 +49,27 @@ describe('hook command', () => {
   })
 
   describe('remove hook', () => {
-    beforeAll(() => {
-      execa.mockReturnValue({ stdout: stubs.coreHooksPath })
-      hook.remove()
+    beforeEach(() => {
+      execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
+      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
     })
 
-    it('should obtain the hooks dir path with execa', () => {
+    it('should remove the hook file', async () => {
+      await hook.remove()
+
       expect(execa).toHaveBeenCalledWith('git', [
         'config',
         '--get',
         'core.hooksPath'
       ])
-    })
+      expect(execa).toHaveBeenCalledWith('git', [
+        'rev-parse',
+        '--absolute-git-dir'
+      ])
 
-    it('should remove the hook file', () => {
       const hookFile = path.resolve(
-        process.cwd(),
-        stubs.coreHooksPath,
+        path.dirname(stubs.gitAbsoluteDir),
+        stubs.relativeCoreHooksPath,
         hookConfig.FILENAME
       )
       expect(fs.unlink).toHaveBeenCalledWith(hookFile, expect.any(Function))

--- a/test/commands/hook.spec.js
+++ b/test/commands/hook.spec.js
@@ -1,5 +1,6 @@
 import execa from 'execa'
 import fs from 'fs'
+import path from 'path'
 
 import hook from '../../src/commands/hook'
 import hookConfig from '../../src/commands/hook/hook'
@@ -16,20 +17,26 @@ describe('hook command', () => {
 
   describe('create hook', () => {
     beforeAll(() => {
-      execa.mockReturnValue({ stdout: stubs.gitAbsoluteDir })
+      execa.mockReturnValue({ stdout: stubs.coreHooksPath })
       hook.create()
     })
 
-    it('should obtain the absolute git dir with execa', () => {
+    it('should obtain the hooks dir path with execa', () => {
       expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
+        'config',
+        '--get',
+        'core.hooksPath'
       ])
     })
 
     it('should create the hook file', () => {
+      const hookFile = path.resolve(
+        process.cwd(),
+        stubs.coreHooksPath,
+        hookConfig.FILENAME
+      )
       expect(fs.writeFile).toHaveBeenCalledWith(
-        stubs.gitAbsoluteDir + hookConfig.PATH,
+        hookFile,
         hookConfig.CONTENTS,
         { mode: hookConfig.PERMISSIONS },
         expect.any(Function)
@@ -39,22 +46,25 @@ describe('hook command', () => {
 
   describe('remove hook', () => {
     beforeAll(() => {
-      execa.mockReturnValue({ stdout: stubs.gitAbsoluteDir })
+      execa.mockReturnValue({ stdout: stubs.coreHooksPath })
       hook.remove()
     })
 
-    it('should obtain the absolute git dir with execa', () => {
+    it('should obtain the hooks dir path with execa', () => {
       expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
+        'config',
+        '--get',
+        'core.hooksPath'
       ])
     })
 
     it('should remove the hook file', () => {
-      expect(fs.unlink).toHaveBeenCalledWith(
-        stubs.gitAbsoluteDir + hookConfig.PATH,
-        expect.any(Function)
+      const hookFile = path.resolve(
+        process.cwd(),
+        stubs.coreHooksPath,
+        hookConfig.FILENAME
       )
+      expect(fs.unlink).toHaveBeenCalledWith(hookFile, expect.any(Function))
     })
   })
 })

--- a/test/commands/hook.spec.js
+++ b/test/commands/hook.spec.js
@@ -1,12 +1,17 @@
-import execa from 'execa'
 import fs from 'fs'
-import path from 'path'
 
 import hook from '../../src/commands/hook'
 import hookConfig from '../../src/commands/hook/hook'
+import getAbsoluteHooksPath from '../../src/utils/getAbsoluteHooksPath'
 import * as stubs from './stubs'
 
+jest.mock('../../src/utils/getAbsoluteHooksPath')
+
 describe('hook command', () => {
+  beforeAll(() => {
+    getAbsoluteHooksPath.mockResolvedValue(stubs.hooksPath)
+  })
+
   it('should match hook module export', () => {
     expect(hook).toMatchSnapshot()
   })
@@ -16,31 +21,12 @@ describe('hook command', () => {
   })
 
   describe('create hook', () => {
-    beforeEach(() => {
-      execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
-      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
-    })
-
     it('should create the hook file', async () => {
       await hook.create()
 
-      expect(execa).toHaveBeenCalledWith('git', [
-        'config',
-        '--get',
-        'core.hooksPath'
-      ])
-      expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
-      ])
-
-      const hookFile = path.resolve(
-        path.dirname(stubs.gitAbsoluteDir),
-        stubs.relativeCoreHooksPath,
-        hookConfig.FILENAME
-      )
+      expect(getAbsoluteHooksPath).toHaveBeenCalledWith(hookConfig.FILENAME)
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        hookFile,
+        stubs.hooksPath,
         hookConfig.CONTENTS,
         { mode: hookConfig.PERMISSIONS }
       )
@@ -48,30 +34,11 @@ describe('hook command', () => {
   })
 
   describe('remove hook', () => {
-    beforeEach(() => {
-      execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
-      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
-    })
-
     it('should remove the hook file', async () => {
       await hook.remove()
 
-      expect(execa).toHaveBeenCalledWith('git', [
-        'config',
-        '--get',
-        'core.hooksPath'
-      ])
-      expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
-      ])
-
-      const hookFile = path.resolve(
-        path.dirname(stubs.gitAbsoluteDir),
-        stubs.relativeCoreHooksPath,
-        hookConfig.FILENAME
-      )
-      expect(fs.unlinkSync).toHaveBeenCalledWith(hookFile)
+      expect(getAbsoluteHooksPath).toHaveBeenCalledWith(hookConfig.FILENAME)
+      expect(fs.unlinkSync).toHaveBeenCalledWith(stubs.hooksPath)
     })
   })
 })

--- a/test/commands/hook.spec.js
+++ b/test/commands/hook.spec.js
@@ -39,11 +39,10 @@ describe('hook command', () => {
         stubs.relativeCoreHooksPath,
         hookConfig.FILENAME
       )
-      expect(fs.writeFile).toHaveBeenCalledWith(
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
         hookFile,
         hookConfig.CONTENTS,
-        { mode: hookConfig.PERMISSIONS },
-        expect.any(Function)
+        { mode: hookConfig.PERMISSIONS }
       )
     })
   })
@@ -72,7 +71,7 @@ describe('hook command', () => {
         stubs.relativeCoreHooksPath,
         hookConfig.FILENAME
       )
-      expect(fs.unlink).toHaveBeenCalledWith(hookFile, expect.any(Function))
+      expect(fs.unlinkSync).toHaveBeenCalledWith(hookFile)
     })
   })
 })

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -24,7 +24,9 @@ export const configAnswers = {
 
 export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'
 
-export const coreHooksPath = '.git/hooks'
+export const absoluteCoreHooksPath = '/etc/git/hooks'
+
+export const relativeCoreHooksPath = '.git/hooks'
 
 export const commitTitle = 'Fix security issue'
 

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -24,6 +24,8 @@ export const configAnswers = {
 
 export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'
 
+export const coreHooksPath = '.git/hooks'
+
 export const commitTitle = 'Fix security issue'
 
 export const commitTitleInvalid = 'Invalid commit `title'

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -28,6 +28,9 @@ export const absoluteCoreHooksPath = '/etc/git/hooks'
 
 export const relativeCoreHooksPath = '.git/hooks'
 
+export const hooksPath =
+  '/Users/carloscuesta/GitHub/gitmoji-cli/.git/hooks/prepare-commit-msg'
+
 export const commitTitle = 'Fix security issue'
 
 export const commitTitleInvalid = 'Invalid commit `title'

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -5,7 +5,9 @@ jest.mock('path-exists')
 jest.mock('fs')
 jest.mock('ora', () =>
   jest.fn().mockReturnValue({
-    start: jest.fn(),
+    start: jest.fn(function () {
+      return this
+    }),
     succeed: jest.fn(),
     fail: jest.fn()
   })

--- a/test/utils/getAbsoluteHooksPath.spec.js
+++ b/test/utils/getAbsoluteHooksPath.spec.js
@@ -1,0 +1,89 @@
+import execa from 'execa'
+// import fs from 'fs'
+import path from 'path'
+
+import getAbsoluteHooksPath from '../../src/utils/getAbsoluteHooksPath'
+import * as stubs from './stubs'
+
+describe('getAbsoluteHooksPath', () => {
+  const hookName = 'pre-commit'
+
+  describe('when the core path is absolute', () => {
+    beforeEach(() => {
+      // simulate the result of "git config --get core.hooksPath"
+      execa.mockReturnValueOnce({ stdout: stubs.absoluteCoreHooksPath })
+    })
+
+    it('returns an absolute path inside it', async () => {
+      const hookFile = await getAbsoluteHooksPath(hookName)
+
+      expect(execa).toHaveBeenCalledWith('git', [
+        'config',
+        '--get',
+        'core.hooksPath'
+      ])
+      expect(hookFile).toEqual(
+        expect.stringContaining(stubs.absoluteCoreHooksPath)
+      )
+      expect(hookFile).toEqual(expect.stringContaining(hookName))
+    })
+  })
+
+  describe('when the core path is relative', () => {
+    beforeEach(() => {
+      // simulate the result of "git config --get core.hooksPath"
+      execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
+      // simulate the result of "git rev-parse --absolute-git-dir" (invoked only when previous result is relative)
+      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
+    })
+
+    it('returns an absolute path inside the git directory', async () => {
+      const hookFile = await getAbsoluteHooksPath(hookName)
+
+      expect(execa).toHaveBeenCalledWith('git', [
+        'config',
+        '--get',
+        'core.hooksPath'
+      ])
+      expect(execa).toHaveBeenCalledWith('git', [
+        'rev-parse',
+        '--absolute-git-dir'
+      ])
+      expect(hookFile).toEqual(
+        expect.stringContaining(path.dirname(stubs.relativeCoreHooksPath))
+      )
+      expect(hookFile).toEqual(
+        expect.stringContaining(stubs.relativeCoreHooksPath)
+      )
+      expect(hookFile).toEqual(expect.stringContaining(hookName))
+    })
+  })
+
+  describe('when the core path is not set in the config', () => {
+    beforeEach(() => {
+      // simulate the result of "git config --get core.hooksPath"
+      execa.mockReturnValueOnce({ stdout: undefined })
+      // simulate the result of "git rev-parse --absolute-git-dir" (invoked only when previous result is relative)
+      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
+    })
+
+    it('returns an absolute path inside the git directory', async () => {
+      const hookFile = await getAbsoluteHooksPath(hookName)
+
+      expect(execa).toHaveBeenCalledWith('git', [
+        'config',
+        '--get',
+        'core.hooksPath'
+      ])
+      expect(execa).toHaveBeenCalledWith('git', [
+        'rev-parse',
+        '--absolute-git-dir'
+      ])
+      expect(hookFile).toEqual(
+        expect.stringContaining(path.dirname(stubs.relativeCoreHooksPath))
+      )
+      expect(hookFile).toEqual(expect.stringContaining('.git/hooks'))
+      expect(hookFile).toEqual(expect.stringContaining(hookName))
+    })
+  })
+})

--- a/test/utils/getAbsoluteHooksPath.spec.js
+++ b/test/utils/getAbsoluteHooksPath.spec.js
@@ -1,6 +1,4 @@
 import execa from 'execa'
-// import fs from 'fs'
-import path from 'path'
 
 import getAbsoluteHooksPath from '../../src/utils/getAbsoluteHooksPath'
 import * as stubs from './stubs'
@@ -10,8 +8,8 @@ describe('getAbsoluteHooksPath', () => {
 
   describe('when the core path is absolute', () => {
     beforeEach(() => {
-      // simulate the result of "git config --get core.hooksPath"
       execa.mockReturnValueOnce({ stdout: stubs.absoluteCoreHooksPath })
+      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
     })
 
     it('returns an absolute path inside it', async () => {
@@ -22,6 +20,10 @@ describe('getAbsoluteHooksPath', () => {
         '--get',
         'core.hooksPath'
       ])
+      expect(execa).toHaveBeenCalledWith('git', [
+        'rev-parse',
+        '--absolute-git-dir'
+      ])
       expect(hookFile).toEqual(
         expect.stringContaining(stubs.absoluteCoreHooksPath)
       )
@@ -31,9 +33,7 @@ describe('getAbsoluteHooksPath', () => {
 
   describe('when the core path is relative', () => {
     beforeEach(() => {
-      // simulate the result of "git config --get core.hooksPath"
       execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
-      // simulate the result of "git rev-parse --absolute-git-dir" (invoked only when previous result is relative)
       execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
     })
 
@@ -49,9 +49,6 @@ describe('getAbsoluteHooksPath', () => {
         'rev-parse',
         '--absolute-git-dir'
       ])
-      expect(hookFile).toEqual(
-        expect.stringContaining(path.dirname(stubs.relativeCoreHooksPath))
-      )
       expect(hookFile).toEqual(
         expect.stringContaining(stubs.relativeCoreHooksPath)
       )
@@ -61,9 +58,7 @@ describe('getAbsoluteHooksPath', () => {
 
   describe('when the core path is not set in the config', () => {
     beforeEach(() => {
-      // simulate the result of "git config --get core.hooksPath"
       execa.mockReturnValueOnce({ stdout: undefined })
-      // simulate the result of "git rev-parse --absolute-git-dir" (invoked only when previous result is relative)
       execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
     })
 
@@ -79,9 +74,7 @@ describe('getAbsoluteHooksPath', () => {
         'rev-parse',
         '--absolute-git-dir'
       ])
-      expect(hookFile).toEqual(
-        expect.stringContaining(path.dirname(stubs.relativeCoreHooksPath))
-      )
+      expect(hookFile).toEqual(expect.stringContaining(stubs.gitAbsoluteDir))
       expect(hookFile).toEqual(expect.stringContaining('.git/hooks'))
       expect(hookFile).toEqual(expect.stringContaining(hookName))
     })

--- a/test/utils/isHookCreated.spec.js
+++ b/test/utils/isHookCreated.spec.js
@@ -1,5 +1,6 @@
 import execa from 'execa'
 import fs from 'fs'
+import path from 'path'
 
 import isHookCreated from '../../src/utils/isHookCreated'
 import HOOK from '../../src/commands/hook/hook'
@@ -7,7 +8,7 @@ import * as stubs from './stubs'
 
 describe('isHookCreated', () => {
   beforeAll(() => {
-    execa.mockReturnValue({ stdout: stubs.gitAbsoluteDir })
+    execa.mockReturnValue({ stdout: stubs.coreHooksPath })
   })
 
   describe('when the hook does not exists', () => {
@@ -20,10 +21,17 @@ describe('isHookCreated', () => {
       const hookExists = await isHookCreated()
 
       expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
+        'config',
+        '--get',
+        'core.hooksPath'
       ])
-      expect(fs.existsSync).toHaveBeenCalledWith(stubs.gitAbsoluteDir + HOOK.PATH)
+
+      const hookFile = path.resolve(
+        process.cwd(),
+        stubs.coreHooksPath,
+        HOOK.FILENAME
+      )
+      expect(fs.existsSync).toHaveBeenCalledWith(hookFile)
       expect(fs.readFileSync).not.toHaveBeenCalled()
       expect(hookExists).toBe(false)
     })
@@ -39,11 +47,20 @@ describe('isHookCreated', () => {
       const hookExists = await isHookCreated()
 
       expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
+        'config',
+        '--get',
+        'core.hooksPath'
       ])
-      expect(fs.existsSync).toHaveBeenCalledWith(stubs.gitAbsoluteDir + HOOK.PATH)
-      expect(fs.readFileSync).toHaveBeenCalledWith(stubs.gitAbsoluteDir + HOOK.PATH, { encoding: 'utf-8' })
+
+      const hookFile = path.resolve(
+        process.cwd(),
+        stubs.coreHooksPath,
+        HOOK.FILENAME
+      )
+      expect(fs.existsSync).toHaveBeenCalledWith(hookFile)
+      expect(fs.readFileSync).toHaveBeenCalledWith(hookFile, {
+        encoding: 'utf-8'
+      })
       expect(hookExists).toBe(true)
     })
   })

--- a/test/utils/isHookCreated.spec.js
+++ b/test/utils/isHookCreated.spec.js
@@ -1,42 +1,27 @@
-import execa from 'execa'
 import fs from 'fs'
-import path from 'path'
 
 import isHookCreated from '../../src/utils/isHookCreated'
+import getAbsoluteHooksPath from '../../src/utils/getAbsoluteHooksPath'
 import HOOK from '../../src/commands/hook/hook'
 import * as stubs from './stubs'
 
+jest.mock('../../src/utils/getAbsoluteHooksPath')
+
 describe('isHookCreated', () => {
-  beforeEach(() => {
-    execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
-    execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
+  beforeAll(() => {
+    getAbsoluteHooksPath.mockResolvedValue(stubs.hooksPath)
   })
 
   describe('when the hook does not exists', () => {
     beforeAll(() => {
       fs.existsSync.mockReturnValue(false)
-      fs.readFileSync.mockReturnValue(HOOK.CONTENTS)
     })
 
     it('should return false', async () => {
       const hookExists = await isHookCreated()
 
-      expect(execa).toHaveBeenCalledWith('git', [
-        'config',
-        '--get',
-        'core.hooksPath'
-      ])
-      expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
-      ])
-
-      const hookFile = path.resolve(
-        path.dirname(stubs.gitAbsoluteDir),
-        stubs.relativeCoreHooksPath,
-        HOOK.FILENAME
-      )
-      expect(fs.existsSync).toHaveBeenCalledWith(hookFile)
+      expect(getAbsoluteHooksPath).toHaveBeenCalledWith(HOOK.FILENAME)
+      expect(fs.existsSync).toHaveBeenCalledWith(stubs.hooksPath)
       expect(fs.readFileSync).not.toHaveBeenCalled()
       expect(hookExists).toBe(false)
     })
@@ -51,23 +36,9 @@ describe('isHookCreated', () => {
     it('should return true', async () => {
       const hookExists = await isHookCreated()
 
-      expect(execa).toHaveBeenCalledWith('git', [
-        'config',
-        '--get',
-        'core.hooksPath'
-      ])
-      expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
-      ])
-
-      const hookFile = path.resolve(
-        path.dirname(stubs.gitAbsoluteDir),
-        stubs.relativeCoreHooksPath,
-        HOOK.FILENAME
-      )
-      expect(fs.existsSync).toHaveBeenCalledWith(hookFile)
-      expect(fs.readFileSync).toHaveBeenCalledWith(hookFile, {
+      expect(getAbsoluteHooksPath).toHaveBeenCalledWith(HOOK.FILENAME)
+      expect(fs.existsSync).toHaveBeenCalledWith(stubs.hooksPath)
+      expect(fs.readFileSync).toHaveBeenCalledWith(stubs.hooksPath, {
         encoding: 'utf-8'
       })
       expect(hookExists).toBe(true)

--- a/test/utils/isHookCreated.spec.js
+++ b/test/utils/isHookCreated.spec.js
@@ -7,8 +7,9 @@ import HOOK from '../../src/commands/hook/hook'
 import * as stubs from './stubs'
 
 describe('isHookCreated', () => {
-  beforeAll(() => {
-    execa.mockReturnValue({ stdout: stubs.coreHooksPath })
+  beforeEach(() => {
+    execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
+    execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
   })
 
   describe('when the hook does not exists', () => {
@@ -25,10 +26,14 @@ describe('isHookCreated', () => {
         '--get',
         'core.hooksPath'
       ])
+      expect(execa).toHaveBeenCalledWith('git', [
+        'rev-parse',
+        '--absolute-git-dir'
+      ])
 
       const hookFile = path.resolve(
-        process.cwd(),
-        stubs.coreHooksPath,
+        path.dirname(stubs.gitAbsoluteDir),
+        stubs.relativeCoreHooksPath,
         HOOK.FILENAME
       )
       expect(fs.existsSync).toHaveBeenCalledWith(hookFile)
@@ -51,10 +56,14 @@ describe('isHookCreated', () => {
         '--get',
         'core.hooksPath'
       ])
+      expect(execa).toHaveBeenCalledWith('git', [
+        'rev-parse',
+        '--absolute-git-dir'
+      ])
 
       const hookFile = path.resolve(
-        process.cwd(),
-        stubs.coreHooksPath,
+        path.dirname(stubs.gitAbsoluteDir),
+        stubs.relativeCoreHooksPath,
         HOOK.FILENAME
       )
       expect(fs.existsSync).toHaveBeenCalledWith(hookFile)

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -408,4 +408,8 @@ export const gitmojisResponse = {
   ]
 }
 
-export const coreHooksPath = '.git/hooks'
+export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'
+
+export const absoluteCoreHooksPath = '/etc/git/hooks'
+
+export const relativeCoreHooksPath = '.git/hooks'

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -413,3 +413,6 @@ export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'
 export const absoluteCoreHooksPath = '/etc/git/hooks'
 
 export const relativeCoreHooksPath = '.git/hooks'
+
+export const hooksPath =
+  '/Users/carloscuesta/GitHub/gitmoji-cli/.git/hooks/prepare-commit-msg'

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -408,4 +408,4 @@ export const gitmojisResponse = {
   ]
 }
 
-export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'
+export const coreHooksPath = '.git/hooks'


### PR DESCRIPTION
- read core.hooksPath from git config (if set)
- default to "process.cwd()/.git/hooks"
- adjust unit tests

## Description

<!-- Explanation about your pull request, what changes you've made -->
Change how the path for git hooks is retrieved:
It now invokes `git config --get core.hooksPath` which provides a *relative* path (default to `.git/hooks` if unset), then create/delete the hooks at that path.

NOTE: @carloscuesta, the previous `git rev-parse` command returned an absolute folder.
Not sure if it is worth defaulting to that command, in case `core.hooksPath` is not set? (to be fully 100% backward-compatible?)

(I do not know if people would try to set-up gitmoji outside of the current working directory, feels edge-case to me 🤷‍♂️)

<!-- Add issue number that this pull request refers to -->
Issue: #577

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
