### PR TITLE
🔧 Automate npm publish with a GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,12 @@ jobs:
         run: |
           yarn install --ignore-scripts
           yarn build
-          yarn package
+      - name: Publish package to NPM 🚀
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+        run: npm publish --token=${{ env.NPM_TOKEN }}
+      - name: Package
+        run: yarn package
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
   ],
   "scripts": {
     "build": "babel src -d lib",
-    "package": "pkg . --output ./bin/gitmoji --targets latest-linux-x64,latest-macos-x64,latest-win-x64",
     "clean": "rm -rf lib",
+    "coverage": "codecov",
     "flow": "flow",
     "lint": "prettier --check src/**/*.js",
-    "coverage": "codecov",
-    "test": "jest",
-    "prepare": "husky install"
+    "package": "pkg . --output ./bin/gitmoji --targets latest-linux-x64,latest-macos-x64,latest-win-x64",
+    "prepare": "husky install",
+    "prepublishOnly": "yarn run lint && yarn run flow && yarn run test",
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Hello! 👋🏼 

This PR automates the process of publishing the package to the `npm` registry. Every time that a new tag `v*` is pushed to the repository, automatically the `release.yml` github workflow will start to publish the package to the registry.

Related with #577 