### PR TITLE
🐛 Fix `getAbsoluteHooksPath` error

### DIFF
--- a/src/utils/getAbsoluteHooksPath.js
+++ b/src/utils/getAbsoluteHooksPath.js
@@ -3,20 +3,22 @@ import execa from 'execa'
 import path from 'path'
 
 const getAbsoluteHooksPath = async (hookName: string): Promise<string> => {
-  const { stdout: coreHooksPath } = await execa('git', [
-    'config',
-    '--get',
-    'core.hooksPath'
-  ])
+  try {
+    const { stdout: coreHooksPath } = await execa('git', [
+      'config',
+      '--get',
+      'core.hooksPath'
+    ])
 
-  const { stdout: gitDirPath } = await execa('git', [
-    'rev-parse',
-    '--absolute-git-dir'
-  ])
+    return path.resolve(coreHooksPath, hookName)
+  } catch (err) {
+    const { stdout: gitDirPath } = await execa('git', [
+      'rev-parse',
+      '--absolute-git-dir'
+    ])
 
-  const hooksPath = coreHooksPath || gitDirPath + '/hooks'
-
-  return path.resolve(hooksPath, hookName)
+    return path.resolve(gitDirPath + '/hooks', hookName)
+  }
 }
 
 export default getAbsoluteHooksPath

--- a/test/utils/getAbsoluteHooksPath.spec.js
+++ b/test/utils/getAbsoluteHooksPath.spec.js
@@ -6,77 +6,39 @@ import * as stubs from './stubs'
 describe('getAbsoluteHooksPath', () => {
   const hookName = 'pre-commit'
 
-  describe('when the core path is absolute', () => {
-    beforeEach(() => {
-      execa.mockReturnValueOnce({ stdout: stubs.absoluteCoreHooksPath })
-      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
+  describe('when core.hooksPath is defined', () => {
+    beforeAll(() => {
+      execa.mockReturnValue({ stdout: stubs.absoluteCoreHooksPath })
     })
 
-    it('returns an absolute path inside it', async () => {
-      const hookFile = await getAbsoluteHooksPath(hookName)
+    it('should return core.hooksPath', async () => {
+      const path = await getAbsoluteHooksPath(hookName)
 
       expect(execa).toHaveBeenCalledWith('git', [
         'config',
         '--get',
         'core.hooksPath'
       ])
-      expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
-      ])
-      expect(hookFile).toEqual(
-        expect.stringContaining(stubs.absoluteCoreHooksPath)
-      )
-      expect(hookFile).toEqual(expect.stringContaining(hookName))
+
+      expect(path).toEqual(`${stubs.absoluteCoreHooksPath}/${hookName}`)
     })
   })
 
-  describe('when the core path is relative', () => {
-    beforeEach(() => {
-      execa.mockReturnValueOnce({ stdout: stubs.relativeCoreHooksPath })
+  describe('when core.hooksPath is not defined', () => {
+    beforeAll(() => {
+      execa.mockReturnValueOnce(new Error('core.hooksPath is not defined'))
       execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
     })
 
-    it('returns an absolute path inside the git directory', async () => {
-      const hookFile = await getAbsoluteHooksPath(hookName)
+    it('should return the default hook path', async () => {
+      const path = await getAbsoluteHooksPath(hookName)
 
-      expect(execa).toHaveBeenCalledWith('git', [
-        'config',
-        '--get',
-        'core.hooksPath'
-      ])
       expect(execa).toHaveBeenCalledWith('git', [
         'rev-parse',
         '--absolute-git-dir'
       ])
-      expect(hookFile).toEqual(
-        expect.stringContaining(stubs.relativeCoreHooksPath)
-      )
-      expect(hookFile).toEqual(expect.stringContaining(hookName))
-    })
-  })
 
-  describe('when the core path is not set in the config', () => {
-    beforeEach(() => {
-      execa.mockReturnValueOnce({ stdout: undefined })
-      execa.mockReturnValueOnce({ stdout: stubs.gitAbsoluteDir })
-    })
-
-    it('returns an absolute path inside the git directory', async () => {
-      const hookFile = await getAbsoluteHooksPath(hookName)
-
-      expect(execa).toHaveBeenCalledWith('git', [
-        'config',
-        '--get',
-        'core.hooksPath'
-      ])
-      expect(execa).toHaveBeenCalledWith('git', [
-        'rev-parse',
-        '--absolute-git-dir'
-      ])
-      expect(hookFile).toEqual(expect.stringContaining(stubs.gitAbsoluteDir))
-      expect(hookFile).toEqual(expect.stringContaining('.git/hooks'))
-      expect(hookFile).toEqual(expect.stringContaining(hookName))
+      expect(path).toEqual(`${stubs.gitAbsoluteDir}/hooks/${hookName}`)
     })
   })
 })


### PR DESCRIPTION
## Description

This fixes #589

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
