### PR TITLE
🔧 Bump minimum required Node version to `v12`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 14.x]
+        node-version: [12.x, 14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Install Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.4.2",
   "description": "A gitmoji client for using emojis on commit messages.",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "bin": {
     "gitmoji": "lib/cli.js"


### PR DESCRIPTION
## Description

This is required as #584 

Node.js v10 is coming to EOL next month 

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
