### PR TITLE
Update getEmojis.js

### DIFF
--- a/src/utils/getEmojis.js
+++ b/src/utils/getEmojis.js
@@ -6,7 +6,7 @@ import ora from 'ora'
 import cache from './emojisCache'
 import buildFetchOptions from './buildFetchOptions'
 
-export const GITMOJIS_URL = 'https://gitmoji.dev/api/gitmojis'
+export const GITMOJIS_URL = 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
 
 const getEmojis = (skipCache: boolean = false) => {
   if (cache.isAvailable() && !skipCache) return cache.getEmojis()


### PR DESCRIPTION
## Fix gitmojis url 
Can't get the gitmojis.json file, when used for the first time.

change the url to https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json

Issue: #635

## Tests

<!-- Ensure that all the tests passed -->

- [x] All tests passed.
