### PR TITLE
🔧 Add gitmojis url config

### DIFF
--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -5,7 +5,8 @@ export const CONFIGURATION_PROMPT_NAMES = {
   AUTO_ADD: 'autoAdd',
   EMOJI_FORMAT: 'emojiFormat',
   SCOPE_PROMPT: 'scopePrompt',
-  SIGNED_COMMIT: 'signedCommit'
+  SIGNED_COMMIT: 'signedCommit',
+  GITMOJIS_URL: 'gitmojisUrl'
 }
 
 export const EMOJI_COMMIT_FORMATS = {
@@ -41,5 +42,11 @@ export default () => [
     message: 'Enable scope prompt',
     type: 'confirm',
     default: configurationVault.getScopePrompt()
+  },
+  {
+    name: CONFIGURATION_PROMPT_NAMES.GITMOJIS_URL,
+    message: 'Set gitmojis api url',
+    type: 'input',
+    default: configurationVault.getGitmojisUrl()
   }
 ]

--- a/src/utils/configurationVault.js
+++ b/src/utils/configurationVault.js
@@ -24,6 +24,10 @@ const setScopePrompt = (scopePrompt: boolean) => {
   config.set(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT, scopePrompt)
 }
 
+const setGitmojisUrl = (gitmojisUrl: string) => {
+  config.set(CONFIGURATION_PROMPT_NAMES.GITMOJIS_URL, gitmojisUrl)
+}
+
 const getAutoAdd = (): boolean => {
   return config.get(CONFIGURATION_PROMPT_NAMES.AUTO_ADD) || false
 }
@@ -43,13 +47,21 @@ const getScopePrompt = (): boolean => {
   return config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT) || false
 }
 
+export const GITMOJIS_URL = 'https://gitmoji.dev/api/gitmojis'
+
+const getGitmojisUrl = (): string => {
+  return config.get(CONFIGURATION_PROMPT_NAMES.GITMOJIS_URL) || GITMOJIS_URL
+}
+
 export default {
   getAutoAdd,
   getEmojiFormat,
   getScopePrompt,
   getSignedCommit,
+  getGitmojisUrl,
   setAutoAdd,
   setEmojiFormat,
   setScopePrompt,
-  setSignedCommit
+  setSignedCommit,
+  setGitmojisUrl
 }

--- a/src/utils/getEmojis.js
+++ b/src/utils/getEmojis.js
@@ -5,15 +5,14 @@ import ora from 'ora'
 
 import cache from './emojisCache'
 import buildFetchOptions from './buildFetchOptions'
-
-export const GITMOJIS_URL = 'https://gitmoji.dev/api/gitmojis'
+import configurationVault from './configurationVault'
 
 const getEmojis = (skipCache: boolean = false) => {
   if (cache.isAvailable() && !skipCache) return cache.getEmojis()
 
   const spinner = ora('Fetching the emoji list').start()
 
-  return fetch(GITMOJIS_URL, buildFetchOptions())
+  return fetch(configurationVault.getGitmojisUrl(), buildFetchOptions())
     .then((response) => response.json())
     .then((data) => {
       const emojis = data.gitmojis

--- a/test/utils/__snapshots__/configurationVault.spec.js.snap
+++ b/test/utils/__snapshots__/configurationVault.spec.js.snap
@@ -4,10 +4,12 @@ exports[`configurationVault should match the module 1`] = `
 Object {
   "getAutoAdd": [Function],
   "getEmojiFormat": [Function],
+  "getGitmojisUrl": [Function],
   "getScopePrompt": [Function],
   "getSignedCommit": [Function],
   "setAutoAdd": [Function],
   "setEmojiFormat": [Function],
+  "setGitmojisUrl": [Function],
   "setScopePrompt": [Function],
   "setSignedCommit": [Function],
 }

--- a/test/utils/configurationVault.spec.js
+++ b/test/utils/configurationVault.spec.js
@@ -1,4 +1,4 @@
-import configurationVault, { config } from '../../src/utils/configurationVault'
+import configurationVault, { config, GITMOJIS_URL } from '../../src/utils/configurationVault'
 import {
   CONFIGURATION_PROMPT_NAMES,
   EMOJI_COMMIT_FORMATS
@@ -28,6 +28,10 @@ describe('configurationVault', () => {
 
     it('should return the default value for scopePrompt', () => {
       expect(configurationVault.getScopePrompt()).toEqual(false)
+    })
+
+    it('should return the default value for gitmojisUrl', () => {
+      expect(configurationVault.getGitmojisUrl()).toEqual(GITMOJIS_URL)
     })
   })
 
@@ -90,6 +94,20 @@ describe('configurationVault', () => {
       )
       expect(config.get).toHaveBeenCalledWith(
         CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT
+      )
+    })
+
+    it('should set and return value for gitmojisUrl', () => {
+      const testGitmojisUrl = 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
+      configurationVault.setGitmojisUrl(testGitmojisUrl)
+      configurationVault.getGitmojisUrl()
+
+      expect(config.set).toHaveBeenCalledWith(
+        CONFIGURATION_PROMPT_NAMES.GITMOJIS_URL,
+        testGitmojisUrl
+      )
+      expect(config.get).toHaveBeenCalledWith(
+        CONFIGURATION_PROMPT_NAMES.GITMOJIS_URL
       )
     })
   })

--- a/test/utils/getEmojis.spec.js
+++ b/test/utils/getEmojis.spec.js
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch'
 
+import configurationVault from '../../src/utils/configurationVault'
 import getEmojis, { GITMOJIS_URL } from '../../src/utils/getEmojis'
 import buildFetchOptions from '../../src/utils/buildFetchOptions'
 import emojisCache from '../../src/utils/emojisCache'
@@ -32,7 +33,7 @@ describe('getEmojis', () => {
     })
 
     it('should fetch the emojis', async () => {
-      expect(fetch).toHaveBeenCalledWith(GITMOJIS_URL, buildFetchOptions())
+      expect(fetch).toHaveBeenCalledWith(configurationVault.getGitmojisUrl(), buildFetchOptions())
     })
 
     it('should create the cache with the fetched emojis', () => {
@@ -55,7 +56,7 @@ describe('getEmojis', () => {
     })
 
     it('should fetch the emojis', async () => {
-      expect(fetch).toHaveBeenCalledWith(GITMOJIS_URL, buildFetchOptions())
+      expect(fetch).toHaveBeenCalledWith(configurationVault.getGitmojisUrl(), buildFetchOptions())
     })
 
     it('should create the cache with the fetched emojis', () => {


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->

`gitmoji.dev` is not accessible in some regions such as China. See Issue: [network](https://github.com/carloscuesta/gitmoji-cli/issues?q=network).

I think it is necessary to allow custom `GITMOJIS_URL`, so that users can even define their own desired list.

For example, use`https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json` instead of `https://gitmoji.dev/api/gitmojis`.

<!-- Add issue number that this pull request refers to -->


## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
