### PR TITLE
✨ Introduce option flags for `commit` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Start the interactive commit client, to auto generate your commit based on your 
 $ gitmoji -c
 ```
 
+##### Options
+
+You can pass default values to the prompts using the following flags:
+
+- `title`: For setting the commit title.
+- `message`: For setting the commit message.
+- `scope`: For setting the commit scope.
+
+Those flags should be used like this:
+
+```bash
+$ gitmoji -c --title="Commit" --message="Message" --scope="Scope"
+```
+
 #### Hook
 
 Run the init option, add your changes and commit them, after that the prompts will begin and your commit message will be built.

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "lint-staged": {
     "*.{js}": [
-      "prettier --write src/**/*.js",
+      "prettier --write",
       "git add"
     ]
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+// @flow
 import meow from 'meow'
 import updateNotifier from 'update-notifier'
 
 import pkg from '../package.json'
 import commands from './commands'
+import FLAGS from './constants/flags'
 import findGitmojiCommand from './utils/findGitmojiCommand'
 
 updateNotifier({ pkg }).notify({ isGlobal: true })
@@ -13,42 +15,42 @@ const cli = meow(
   Usage
     $ gitmoji
   Options
-    --commit, -c    Interactively commit using the prompts
-    --config, -g    Setup gitmoji-cli preferences.
-    --init, -i      Initialize gitmoji as a commit hook
-    --list, -l      List all the available gitmojis
-    --remove, -r    Remove a previously initialized commit hook
-    --search, -s    Search gitmojis
-    --update, -u    Sync emoji list with the repo
-    --version, -v   Print gitmoji-cli installed version
+    --${FLAGS.COMMIT}, -c    Interactively commit using the prompts
+    --${FLAGS.CONFIG}, -g    Setup gitmoji-cli preferences.
+    --${FLAGS.INIT}, -i      Initialize gitmoji as a commit hook
+    --${FLAGS.LIST}, -l      List all the available gitmojis
+    --${FLAGS.REMOVE}, -r    Remove a previously initialized commit hook
+    --${FLAGS.SEARCH}, -s    Search gitmojis
+    --${FLAGS.UPDATE}, -u    Sync emoji list with the repo
+    --${FLAGS.VERSION}, -v   Print gitmoji-cli installed version
   Examples
     $ gitmoji -l
     $ gitmoji bug linter -s
 `,
   {
     flags: {
-      commit: { type: 'boolean', alias: 'c' },
-      config: { type: 'boolean', alias: 'g' },
-      help: { type: 'boolean', alias: 'h' },
-      init: { type: 'boolean', alias: 'i' },
-      list: { type: 'boolean', alias: 'l' },
-      remove: { type: 'boolean', alias: 'r' },
-      search: { type: 'boolean', alias: 's' },
-      update: { type: 'boolean', alias: 'u' },
-      version: { type: 'boolean', alias: 'v' }
+      [FLAGS.COMMIT]: { type: 'boolean', alias: 'c' },
+      [FLAGS.CONFIG]: { type: 'boolean', alias: 'g' },
+      [FLAGS.HELP]: { type: 'boolean', alias: 'h' },
+      [FLAGS.INIT]: { type: 'boolean', alias: 'i' },
+      [FLAGS.LIST]: { type: 'boolean', alias: 'l' },
+      [FLAGS.REMOVE]: { type: 'boolean', alias: 'r' },
+      [FLAGS.SEARCH]: { type: 'boolean', alias: 's' },
+      [FLAGS.UPDATE]: { type: 'boolean', alias: 'u' },
+      [FLAGS.VERSION]: { type: 'boolean', alias: 'v' }
     }
   }
 )
 
 export const options = {
-  commit: () => commands.commit('client'),
-  config: () => commands.config(),
-  hook: () => commands.commit('hook'),
-  init: () => commands.createHook(),
-  list: () => commands.list(),
-  remove: () => commands.removeHook(),
-  search: () => cli.input.map((input) => commands.search(input)),
-  update: () => commands.update()
+  [FLAGS.COMMIT]: (options: Object) => commands.commit(options),
+  [FLAGS.CONFIG]: () => commands.config(),
+  [FLAGS.HOOK]: (options: Object) => commands.commit(options),
+  [FLAGS.INIT]: () => commands.createHook(),
+  [FLAGS.LIST]: () => commands.list(),
+  [FLAGS.REMOVE]: () => commands.removeHook(),
+  [FLAGS.SEARCH]: () => cli.input.map((input) => commands.search(input)),
+  [FLAGS.UPDATE]: () => commands.update()
 }
 
 findGitmojiCommand(cli, options)

--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -3,32 +3,38 @@ import inquirer from 'inquirer'
 
 import getEmojis from '../../utils/getEmojis'
 import prompts from './prompts'
+import COMMIT_MODES from '../../constants/commit'
 import withHook, {
   registerHookInterruptionHandler,
   cancelIfNeeded
 } from './withHook'
 import withClient from './withClient'
 
-export type CommitMode = 'client' | 'hook'
-
-const commit = (mode: CommitMode) => {
-  if (mode === 'hook') {
-    registerHookInterruptionHandler()
-    return cancelIfNeeded().then(() => promptAndCommit(mode))
-  }
-
-  return promptAndCommit(mode)
+export type CommitOptions = {
+  message?: string,
+  mode: typeof COMMIT_MODES.CLIENT | typeof COMMIT_MODES.HOOK,
+  scope?: string,
+  title?: string,
 }
 
-const promptAndCommit = (mode: 'client' | 'hook') =>
+const promptAndCommit = (options: CommitOptions) =>
   getEmojis()
-    .then((gitmojis) => prompts(gitmojis, mode))
+    .then((gitmojis) => prompts(gitmojis, options))
     .then((questions) => {
       inquirer.prompt(questions).then((answers) => {
-        if (mode === 'hook') return withHook(answers)
+        if (options.mode === COMMIT_MODES.HOOK) return withHook(answers)
 
         return withClient(answers)
       })
     })
+
+const commit = (options: CommitOptions) => {
+  if (options.mode === COMMIT_MODES.HOOK) {
+    registerHookInterruptionHandler()
+    return cancelIfNeeded().then(() => promptAndCommit(options))
+  }
+
+  return promptAndCommit(options)
+}
 
 export default commit

--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -4,7 +4,7 @@ import inquirer from 'inquirer'
 import configurationVault from '../../utils/configurationVault'
 import filterGitmojis from '../../utils/filterGitmojis'
 import getDefaultCommitContent from '../../utils/getDefaultCommitContent'
-import { type CommitMode } from './index'
+import { type CommitOptions } from './index'
 import guard from './guard'
 
 const TITLE_MAX_LENGTH_COUNT: number = 48
@@ -25,8 +25,8 @@ export type Answers = {
   message: string
 }
 
-export default (gitmojis: Array<Gitmoji>, mode: CommitMode): Array<Object> => {
-  const { title, message } = getDefaultCommitContent(mode)
+export default (gitmojis: Array<Gitmoji>, options: CommitOptions): Array<Object> => {
+  const { title, message, scope } = getDefaultCommitContent(options)
 
   return [
     {
@@ -47,7 +47,8 @@ export default (gitmojis: Array<Gitmoji>, mode: CommitMode): Array<Object> => {
           {
             name: 'scope',
             message: 'Enter the scope of current changes:',
-            validate: guard.scope
+            validate: guard.scope,
+            ...(scope ? { default: scope } : {})
           }
         ]
       : []),

--- a/src/constants/commit.js
+++ b/src/constants/commit.js
@@ -1,0 +1,7 @@
+// @flow
+const COMMIT_MODES = {
+  CLIENT: 'client',
+  HOOK: 'hook'
+}
+
+export default COMMIT_MODES

--- a/src/constants/flags.js
+++ b/src/constants/flags.js
@@ -1,0 +1,15 @@
+// @flow
+const FLAGS = {
+  COMMIT: 'commit',
+  CONFIG: 'config',
+  HELP: 'help',
+  HOOK: 'hook',
+  INIT: 'init',
+  LIST: 'list',
+  REMOVE: 'remove',
+  SEARCH: 'search',
+  UPDATE: 'update',
+  VERSION: 'version'
+}
+
+export default FLAGS

--- a/src/utils/findGitmojiCommand.js
+++ b/src/utils/findGitmojiCommand.js
@@ -1,12 +1,31 @@
 // @flow
+import COMMIT_MODES from '../constants/commit'
+import FLAGS from '../constants/flags'
+
+const getOptionsForCommand = (command: ?string, flags: Object) => {
+  const commandsWithOptions = [FLAGS.COMMIT, FLAGS.HOOK]
+
+  if (commandsWithOptions.includes(command)) {
+    return {
+      message: flags['message'],
+      mode: command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
+      scope: flags['scope'],
+      title: flags['title']
+    }
+  }
+
+  return null
+}
+
 const findGitmojiCommand = (cli: any, options: Object) => {
   const flags = cli.flags
-  const matchedFlagsWithInput = Object.keys(flags)
+  const commandFlag = Object.keys(flags)
     .map((flag) => flags[flag] && flag)
-    .filter((flag) => options[flag])
+    .find((flag) => options[flag])
+  const commandOptions = getOptionsForCommand(commandFlag, flags)
 
-  return options[matchedFlagsWithInput]
-    ? options[matchedFlagsWithInput]()
+  return options[commandFlag]
+    ? options[commandFlag](commandOptions)
     : cli.showHelp()
 }
 

--- a/src/utils/getDefaultCommitContent.js
+++ b/src/utils/getDefaultCommitContent.js
@@ -1,15 +1,16 @@
 // @flow
 import fs from 'fs'
 
-import { type CommitMode } from '../commands/commit'
+import { type CommitOptions } from '../commands/commit/index'
+import COMMIT_MODES from '../constants/commit'
 
 const COMMIT_FILE_PATH_INDEX = 3
 const COMMIT_TITLE_LINE_INDEX = 0
 const COMMIT_MESSAGE_LINE_INDEX = 2
 
 const getDefaultCommitContent = (
-  mode: CommitMode
-): { title: ?string, message: ?string } => {
+  options: CommitOptions
+): { title: ?string, message: ?string, scope: ?string } => {
   /*
     Since the hook is called with `gitmoji --hook $1`
     According to https://git-scm.com/docs/githooks#_prepare_commit_msg,
@@ -17,10 +18,11 @@ const getDefaultCommitContent = (
   */
   const commitFilePath: string = process.argv[COMMIT_FILE_PATH_INDEX]
 
-  if (mode === 'client' || !fs.existsSync(commitFilePath)) {
+  if (options.mode === COMMIT_MODES.CLIENT || !fs.existsSync(commitFilePath)) {
     return {
-      title: null,
-      message: null
+      message: options['message'] || null,
+      scope: options['scope'] || null,
+      title: options['title'] || null
     }
   }
 
@@ -30,11 +32,12 @@ const getDefaultCommitContent = (
     .split('\n')
 
   return {
-    title: commitFileContent[COMMIT_TITLE_LINE_INDEX],
     message:
       commitFileContent.length > COMMIT_MESSAGE_LINE_INDEX
         ? commitFileContent[COMMIT_MESSAGE_LINE_INDEX]
-        : null
+        : null,
+    scope: options['scope'],
+    title: commitFileContent[COMMIT_TITLE_LINE_INDEX]
   }
 }
 

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -32,7 +32,7 @@ describe('commit command', () => {
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent
         )
-        commit('client')
+        commit({ mode: 'client' })
       })
 
       it('should call inquirer with prompts', () => {
@@ -68,7 +68,7 @@ describe('commit command', () => {
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent
         )
-        commit('client')
+        commit({ mode: 'client' })
       })
 
       it('should call inquirer with prompts', () => {
@@ -106,7 +106,7 @@ describe('commit command', () => {
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent
         )
-        commit('client')
+        commit({ mode: 'client' })
       })
 
       it('should call inquirer with prompts', () => {
@@ -136,7 +136,7 @@ describe('commit command', () => {
         )
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         fs.existsSync.mockReturnValueOnce(false).mockReturnValueOnce(false)
-        commit('hook')
+        commit({ mode: 'hook' })
       })
 
       it('should commit using the hook', () => {
@@ -166,7 +166,7 @@ describe('commit command', () => {
         )
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         fs.existsSync.mockReturnValueOnce(false).mockReturnValueOnce(false)
-        commit('hook')
+        commit({ mode: 'hook' })
       })
 
       it('should commit using the hook', () => {
@@ -195,7 +195,7 @@ describe('commit command', () => {
         fs.existsSync.mockReturnValueOnce(true)
 
         try {
-          await commit('hook')
+          await commit({ mode: 'hook' })
         } catch (e) {
           expect(e.message).toMatch('ProcessExit0')
         }
@@ -217,7 +217,7 @@ describe('commit command', () => {
         process.argv[COMMIT_MESSAGE_SOURCE] = 'commit sha123'
 
         try {
-          await commit('hook')
+          await commit({ mode: 'hook' })
         } catch (e) {
           expect(e.message).toMatch('ProcessExit0')
         }
@@ -257,7 +257,7 @@ describe('commit command', () => {
         )
 
         try {
-          await commit('hook')
+          await commit({ mode: 'hook' })
         } catch (e) {
           expect(e.message).toMatch('SIGINT')
         }

--- a/test/utils/findGitmojiCommand.spec.js
+++ b/test/utils/findGitmojiCommand.spec.js
@@ -1,8 +1,22 @@
 import findGitmojiCommand from '../../src/utils/findGitmojiCommand'
+import FLAGS from '../../src/constants/flags'
+import COMMIT_MODES from '../../src/constants/commit'
 import * as stubs from './stubs'
 
 describe('findGitmojiCommand', () => {
   stubs.commands.map((command) => {
+    if ([FLAGS.COMMIT, FLAGS.HOOK].includes(command)) {
+      it(`it should match ${command} command`, () => {
+        findGitmojiCommand(stubs.cliMock({ [command]: true }), stubs.optionsMock)
+        expect(stubs.optionsMock[command]).toHaveBeenCalledWith({
+          mode: command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
+          message: undefined,
+          scope: undefined,
+          title: undefined,
+        })
+      })
+    }
+
     it(`it should match ${command} command`, () => {
       findGitmojiCommand(stubs.cliMock({ [command]: true }), stubs.optionsMock)
       expect(stubs.optionsMock[command]).toHaveBeenCalled()

--- a/test/utils/getDefaultCommitContent.spec.js
+++ b/test/utils/getDefaultCommitContent.spec.js
@@ -11,14 +11,14 @@ describe('getDefaultCommitContent', () => {
     })
 
     it('should retrieve title and message in hook mode', () => {
-      const { title, message } = getDefaultCommitContent('hook')
+      const { title, message } = getDefaultCommitContent({ mode: 'hook' })
 
       expect(title).toBe('commit title')
       expect(message).toBe('commit message')
     })
 
     it('should retrieve null title and message in client mode', () => {
-      const { title, message } = getDefaultCommitContent('client')
+      const { title, message } = getDefaultCommitContent({ mode: 'client' })
 
       expect(title).toBe(null)
       expect(message).toBe(null)
@@ -31,7 +31,7 @@ describe('getDefaultCommitContent', () => {
     })
 
     it('should retrieve null title and message', () => {
-      const { title, message } = getDefaultCommitContent('hook')
+      const { title, message } = getDefaultCommitContent({ mode: 'hook' })
 
       expect(title).toBe(null)
       expect(message).toBe(null)


### PR DESCRIPTION
## Description

This PR introduces the possibility of passing options to the `commit` and `hook` commands:

- `--title`
- `--message`
- `--scope`

Example usage:

```
$ gitmoji -c --title="Commit title" --message="Commit message" --scope="SCOPE-123"
```

The feature is intended for "advanced" users who might want to not introduce the prompts on the "interactive" prompt part.

Fixes #465 

## Demo

https://user-images.githubusercontent.com/7629661/128042792-007bd989-04cf-4572-a13c-6c9c77f4c0b2.mov


## Tests

- [x] All tests passed.
