### PR TITLE
Fix `getEmojis` from cache when is empty

### DIFF
--- a/src/utils/emojisCache.js
+++ b/src/utils/emojisCache.js
@@ -15,7 +15,7 @@ export const CACHE_PATH = path.join(
   GITMOJI_CACHE.FILE
 )
 
-const createEmojis = (emojis: Array<Object>) => {
+const createEmojis = (emojis: Array<Object>): void => {
   if (!pathExists.sync(path.dirname(CACHE_PATH))) {
     fs.mkdirSync(path.dirname(CACHE_PATH))
   }
@@ -23,12 +23,15 @@ const createEmojis = (emojis: Array<Object>) => {
   fs.writeFileSync(CACHE_PATH, JSON.stringify(emojis))
 }
 
-const getEmojis = () => {
-  // $FlowFixMe
-  return Promise.resolve(JSON.parse(fs.readFileSync(CACHE_PATH)))
+const getEmojis = (): Array<Object> => {
+  try {
+    return JSON.parse(fs.readFileSync(CACHE_PATH).toString())
+  } catch (error) {
+    return []
+  }
 }
 
-const isAvailable = () => pathExists.sync(CACHE_PATH)
+const isAvailable = (): boolean => pathExists.sync(CACHE_PATH)
 
 export default {
   createEmojis,

--- a/src/utils/getEmojis.js
+++ b/src/utils/getEmojis.js
@@ -10,7 +10,7 @@ import configurationVault from './configurationVault'
 const getEmojis = async (
   skipCache: boolean = false
 ): Promise<Array<Object>> => {
-  const emojisFromCache = await cache.getEmojis()
+  const emojisFromCache = cache.getEmojis()
 
   if (cache.isAvailable() && !skipCache) return emojisFromCache
 

--- a/test/utils/emojisCache.spec.js
+++ b/test/utils/emojisCache.spec.js
@@ -70,13 +70,32 @@ describe('emojisCache', () => {
   })
 
   describe('getEmojis', () => {
-    beforeAll(() => {
-      fs.readFileSync.mockReturnValue(JSON.stringify(stubs.gitmojis))
-      emojisCache.getEmojis()
+    describe('when cache exists', () => {
+      beforeAll(() => {
+        fs.readFileSync.mockReturnValue(JSON.stringify(stubs.gitmojis))
+      })
+
+      it('should read and return the emojis from the cache', () => {
+        const emojis = emojisCache.getEmojis()
+
+        expect(fs.readFileSync).toHaveBeenCalledWith(CACHE_PATH)
+        expect(emojis).toEqual(stubs.gitmojis)
+      })
     })
 
-    it('should read the emojis from the cache', () => {
-      expect(fs.readFileSync).toHaveBeenCalled()
+    describe('when cache doesn\'t exists', () => {
+      beforeAll(() => {
+        fs.readFileSync.mockImplementation(() => {
+          throw new Error('ERROR: Cache doesn\'t exist')
+        })
+      })
+
+      it('should return an empty array', () => {
+        const emojis = emojisCache.getEmojis()
+
+        expect(fs.readFileSync).toHaveBeenCalled()
+        expect(emojis).toEqual([])
+      })
     })
   })
 })


### PR DESCRIPTION
## Description

Fixes #658 

This was introduced in #657, as we're trying to access the `cache` file without checking if it was available or not.

## Tests

- [x] All tests passed.
