### PR TITLE
🚸 Improve `commit` command errors output

### DIFF
--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -37,7 +37,7 @@ const withClient = async (answers: Answers) => {
 
     console.log(stdout)
   } catch (error) {
-    console.error(error)
+    console.error(chalk.red('\nOops! An error ocurred:\n') + error.stdout)
   }
 }
 

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -118,6 +118,32 @@ describe('commit command', () => {
         expect(execa).not.toHaveBeenCalledWith()
       })
     })
+
+    describe('when an error happens', () => {
+      const consoleError = jest.spyOn(console, 'error')
+
+      beforeAll(() => {
+        consoleError.mockImplementation((msg) => msg)
+        inquirer.prompt.mockReturnValue(
+          Promise.resolve(stubs.clientCommitAnswersWithScope)
+        )
+        getEmojis.mockResolvedValue(stubs.gitmojis)
+        isHookCreated.mockResolvedValue(false)
+        configurationVault.getAutoAdd.mockReturnValue(true)
+        configurationVault.getSignedCommit.mockReturnValue(true)
+        getDefaultCommitContent.mockReturnValueOnce(
+          stubs.emptyDefaultCommitContent
+        )
+        execa.mockImplementation(() => {
+          throw new Error({ stdout: 'Hey' })
+        })
+        commit({ mode: 'client' })
+      })
+
+      it('should print the error to the console', () => {
+        expect(consoleError).toHaveBeenCalledWith(expect.any(String))
+      })
+    })
   })
 
   describe('withHook', () => {


### PR DESCRIPTION
## Description

This PR improves the UX of the errors printed to the console when using the `commit` command in client mode

Fixes #610 

## Demo

### Before

<img width="1440" alt="Screen Shot 2021-08-04 at 20 34 12" src="https://user-images.githubusercontent.com/7629661/128235786-4075547e-9167-443f-8616-911f351295f9.png">

### After

<img width="1440" alt="Screen Shot 2021-08-04 at 20 34 39" src="https://user-images.githubusercontent.com/7629661/128235797-ce6342c6-e693-493c-ba32-34b039c81c51.png">

## Tests

- [x] All tests passed.
