### PR TITLE
🐛 Custom gitmojis url was not set

### DIFF
--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -16,6 +16,9 @@ const config = () => {
     configurationVault.setScopePrompt(
       answers[CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT]
     )
+    configurationVault.setGitmojisUrl(
+      answers[CONFIGURATION_PROMPT_NAMES.GITMOJIS_URL]
+    )
   })
 }
 

--- a/test/commands/config.spec.js
+++ b/test/commands/config.spec.js
@@ -30,5 +30,8 @@ describe('config command', () => {
     expect(configurationVault.setScopePrompt).toHaveBeenCalledWith(
       stubs.configAnswers.scopePrompt
     )
+    expect(configurationVault.setGitmojisUrl).toHaveBeenCalledWith(
+      stubs.configAnswers.gitmojisUrl
+    )
   })
 })

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -1,3 +1,5 @@
+import { GITMOJIS_URL } from "../../src/utils/configurationVault"
+
 export const gitmojis = [
   {
     emoji: '❤️',
@@ -19,7 +21,8 @@ export const configAnswers = {
   autoAdd: true,
   emojiFormat: 'emoji',
   signedCommit: true,
-  scopePrompt: false
+  scopePrompt: false,
+  gitmojisUrl: GITMOJIS_URL
 }
 
 export const gitAbsoluteDir = '/Users/carloscuesta/GitHub/gitmoji-cli/.git'


### PR DESCRIPTION
## Description

Thanks to [🔧 Add gitmojis url config by YunYouJun · Pull Request #640](https://github.com/carloscuesta/gitmoji-cli/pull/640), you can custom `GITMOJIS_URL`.
But It didn't seem to be working.

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
