### PR TITLE
✨ Support stdout streaming

### DIFF
--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -26,18 +26,20 @@ const withClient = async (answers: Answers) => {
 
     if (configurationVault.getAutoAdd()) await execa('git', ['add', '.'])
 
-    const { stdout } = await execa('git', [
-      'commit',
-      ...isSigned,
-      '-m',
-      title,
-      '-m',
-      answers.message
-    ])
-
-    console.log(stdout)
+    await execa(
+      'git',
+      ['commit', ...isSigned, '-m', title, '-m', answers.message],
+      {
+        buffer: false,
+        stdio: 'inherit'
+      }
+    )
   } catch (error) {
-    console.error(chalk.red('\nOops! An error ocurred:\n') + error.stdout)
+    console.error(
+      chalk.red(
+        '\nOops! An error ocurred. There is likely additional logging output above.\n'
+      )
+    )
   }
 }
 

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -22,7 +22,6 @@ describe('commit command', () => {
   describe('withClient', () => {
     describe('with no autoAdd and no signed commits and no scope', () => {
       beforeAll(() => {
-        console.log = jest.fn()
         execa.mockReturnValue({ stdout: stubs.commitResult })
         inquirer.prompt.mockReturnValue(
           Promise.resolve(stubs.clientCommitAnswers)
@@ -40,23 +39,25 @@ describe('commit command', () => {
       })
 
       it('should call execa with the commit command based on answers', () => {
-        expect(execa).toHaveBeenCalledWith('git', [
-          'commit',
-          '-m',
-          `${stubs.clientCommitAnswers.gitmoji} ${stubs.clientCommitAnswers.title}`,
-          '-m',
-          stubs.clientCommitAnswers.message
-        ])
-      })
-
-      it('should print the result to the console', () => {
-        expect(console.log).toHaveBeenCalledWith(stubs.commitResult)
+        expect(execa).toHaveBeenCalledWith(
+          'git',
+          [
+            'commit',
+            '-m',
+            `${stubs.clientCommitAnswers.gitmoji} ${stubs.clientCommitAnswers.title}`,
+            '-m',
+            stubs.clientCommitAnswers.message
+          ],
+          {
+            buffer: false,
+            stdio: 'inherit'
+          }
+        )
       })
     })
 
     describe('with autoAdd, signed commits and scope', () => {
       beforeAll(() => {
-        console.log = jest.fn()
         execa.mockReturnValue({ stdout: stubs.commitResult })
         inquirer.prompt.mockReturnValue(
           Promise.resolve(stubs.clientCommitAnswersWithScope)
@@ -80,24 +81,26 @@ describe('commit command', () => {
       })
 
       it('should call execa with the commit command based on answers', () => {
-        expect(execa).toHaveBeenLastCalledWith('git', [
-          'commit',
-          '-S',
-          '-m',
-          `${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}`,
-          '-m',
-          stubs.clientCommitAnswersWithScope.message
-        ])
-      })
-
-      it('should print the result to the console', () => {
-        expect(console.log).toHaveBeenCalledWith(stubs.commitResult)
+        expect(execa).toHaveBeenLastCalledWith(
+          'git',
+          [
+            'commit',
+            '-S',
+            '-m',
+            `${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}`,
+            '-m',
+            stubs.clientCommitAnswersWithScope.message
+          ],
+          {
+            buffer: false,
+            stdio: 'inherit'
+          }
+        )
       })
     })
 
     describe('with the commit hook created', () => {
       beforeAll(() => {
-        console.log = jest.fn()
         inquirer.prompt.mockReturnValue(
           Promise.resolve(stubs.clientCommitAnswers)
         )
@@ -114,7 +117,6 @@ describe('commit command', () => {
       })
 
       it('should stop the commit because the hook is created and log the explanation to the user', () => {
-        expect(console.log).toHaveBeenCalledWith(expect.any(String))
         expect(execa).not.toHaveBeenCalledWith()
       })
     })


### PR DESCRIPTION
## Description

Support streaming of stdout/stderr while using `gitmoji -c`, quite important when using pre-commit hook

### success:
![2021-08-26-23-27-15](https://user-images.githubusercontent.com/28385941/131038499-54ec60e0-c198-475d-a5a6-95762499ca5d.gif)
### error:
![2021-08-27-09-31-08](https://user-images.githubusercontent.com/28385941/131090107-296dff3c-a200-4f12-8eed-c08aac8bcf99.gif)

<!-- Explanation about your pull request, what changes you've made -->

<!-- Add issue number that this pull request refers to -->
Issue: https://github.com/carloscuesta/gitmoji-cli/issues/291

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed. 
notes on tests:

developing the feature was quite easy, the very difficult part that I didn't crack yet, is testing, when using buffer stream we are not using `console.log` anymore, meaning tests like: https://github.com/carloscuesta/gitmoji-cli/blob/edf1f3b9081e259311af1da03b288e182b1a101e/test/commands/commit.spec.js#L53 
becomes impossible to implement, as Jest is not  able to mock `process.stdout`: https://github.com/facebook/jest/issues/9984

One possible mitigation was to listen on execa stream and use console.log on data events, but the compromise is that each line printed by the pre-commit hook is added a line carriage return.

At this point I would recommend dropping the tests in questions (which I did in this pr for now).

What do you think @carloscuesta ?
