### PR TITLE
🐛 cancel hook when automerge by git pull

### DIFF
--- a/src/commands/commit/withHook/index.js
+++ b/src/commands/commit/withHook/index.js
@@ -51,7 +51,11 @@ export const cancelIfAmending = () =>
       `gitmoji --hook $1 $2`
     */
     const commitMessageSource: ?string = process.argv[COMMIT_MESSAGE_SOURCE]
-    if (commitMessageSource && commitMessageSource.startsWith('commit')) {
+    if (
+      commitMessageSource &&
+      (commitMessageSource.startsWith('commit') ||
+        commitMessageSource.startsWith('merge'))
+    ) {
       process.exit(0)
     }
     resolve()

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -303,6 +303,25 @@ describe('commit command', () => {
         expect(process.exit).toHaveBeenCalledWith(0)
       })
     })
+
+    describe('with git auto merge trigger by git pull', () => {
+      it('should cancel the hook', async () => {
+        mockProcess.mockProcessExit(new Error('ProcessExit0'))
+        execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
+        // mock that we are merging
+        process.argv[3] = '.git/MERGE_MSG'
+        process.argv[COMMIT_MESSAGE_SOURCE] = 'merge'
+
+        try {
+          await commit({ mode: 'hook' })
+        } catch (e) {
+          expect(e.message).toMatch('ProcessExit0')
+        }
+
+        expect(process.exit).toHaveBeenCalledWith(0)
+      })
+    })
+
   })
 
   describe('guard', () => {


### PR DESCRIPTION
✅  add test

## Description

cancel hook when automerge by git pull.
add check commitMessageSource equas 'merge' in commands/commit/withHook/index.js#cancelIfAmending function

Issue: #782

## Tests

<!-- Ensure that all the tests passed -->
- [ ✅ ] All tests passed.
