### PR TITLE
🔧 Update babel/preset-env target node version 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "@babel/preset-env",
         {
           "targets": {
-            "node": "10"
+            "node": "12"
           }
         }
       ],


### PR DESCRIPTION
## Description

The Node.js minimum required version for this package was bumped some time ago, we can bump the babel preset env target version to 12.