### PR TITLE
[Dependencies] Bump execa

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "chalk": "4.1.0",
     "conf": "10.1.2",
-    "execa": "5.0.0",
+    "execa": "5.1.1",
     "fuse.js": "6.4.1",
     "inquirer": "8.2.2",
     "inquirer-autocomplete-prompt": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,22 +2405,7 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-execa@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
-  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
-  dependencies:
-    cross-spawn "^7.0.3"
-    get-stream "^6.0.0"
-    human-signals "^2.1.0"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.1"
-    onetime "^5.1.2"
-    signal-exit "^3.0.3"
-    strip-final-newline "^2.0.0"
-
-execa@^5.0.0, execa@^5.1.1:
+execa@5.1.1, execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==


### PR DESCRIPTION
## Description

This PR bumps the version of "execa" so it matches the functionality used.

In https://github.com/carloscuesta/gitmoji-cli/blob/master/src/commands/commit/withClient/index.js#L45 the `error.escapedCommand` is used to render the failed git command.
However, this property is not added until execa v5.1.0: https://github.com/sindresorhus/execa/releases/tag/v5.1.0

As such, the commit command funcitonality was "broken" with release https://github.com/carloscuesta/gitmoji-cli/releases/tag/v4.10.0 where dependency versions were made fixed.

Issue: No issue created

## Tests

- [ ] All tests passed.
