### PR TITLE
💥Bump Node.js minimum required version to `14.x`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Install Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.13.1",
   "description": "A gitmoji client for using emojis on commit messages.",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "bin": {
     "gitmoji": "lib/cli.js"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR bumps the minimum required node version to `v14`.