### PR TITLE
👷 Update npm publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Build
         run: |
           yarn install --ignore-scripts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,9 @@ jobs:
       - name: Publish package to NPM 🚀
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
-        run: npm publish --token=${{ env.NPM_TOKEN }}
+        run: |
+         npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+         npm publish
       - name: Package
         run: yarn package
       - name: Create Release


### PR DESCRIPTION
## Description

This PR updates the `node-version` of the `release` action to `16` and updates the publish authentication method.
