### PR TITLE
use .cache/gitmoji folder for cache to respect xdg specifications

### DIFF
--- a/src/utils/emojisCache.js
+++ b/src/utils/emojisCache.js
@@ -5,7 +5,7 @@ import path from 'path'
 import pathExists from 'path-exists'
 
 export const GITMOJI_CACHE: Object = {
-  FOLDER: '.gitmoji',
+  FOLDER: '.cache/gitmoji',
   FILE: 'gitmojis.json'
 }
 

--- a/test/utils/__snapshots__/emojisCache.spec.js.snap
+++ b/test/utils/__snapshots__/emojisCache.spec.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`emojisCache should match CACHE_PATH 1`] = `"/Users/Test/.gitmoji/gitmojis.json"`;
+exports[`emojisCache should match CACHE_PATH 1`] = `"/Users/Test/.cache/gitmoji/gitmojis.json"`;
 
 exports[`emojisCache should match GITMOJI_CACHE 1`] = `
 Object {
   "FILE": "gitmojis.json",
-  "FOLDER": ".gitmoji",
+  "FOLDER": ".cache/gitmoji",
 }
 `;


### PR DESCRIPTION
## Description

Update the script to use a xdg compliant folder for cache file.

<!-- Add issue number that this pull request refers to -->
Issue: #893