### PR TITLE
♻️ Use `babel-plugin-module-resolver` for imports

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 <PROJECT_ROOT>/node_modules/@babel/core/node_modules/resolve/test/resolver/malformed_package_json
 <PROJECT_ROOT>/node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve/test/resolver/malformed_package_json
 <PROJECT_ROOT>/node_modules/resolve/test/resolver/malformed_package_json
+<PROJECT_ROOT>/node_modules/babel-plugin-module-resolver/node_modules/resolve/test/resolver/malformed_package_json
 
 [include]
 
@@ -10,6 +11,9 @@
 [lints]
 
 [options]
+module.name_mapper='^@utils\/\(.*\)$' -> '<PROJECT_ROOT>/src/utils/\1'
+module.name_mapper='^@constants\/\(.*\)$' -> '<PROJECT_ROOT>/src/constants/\1'
+module.name_mapper='^@commands\/\(.*\)$' -> '<PROJECT_ROOT>/src/commands/\1'
 
 [strict]
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@utils/*": ["src/utils/*"],
+      "@commands/*": ["src/commands/*"],
+      "@/constants*": ["src/constants/*"],
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -108,7 +108,12 @@
     ],
     "setupFiles": [
       "./test/setupTests.js"
-    ]
+    ],
+    "moduleNameMapper": {
+      "@utils/(.*)$": "<rootDir>/src/utils/$1",
+      "@commands/(.*)$": "<rootDir>/src/commands/$1",
+      "@constants/(.*)$": "<rootDir>/src/constants/$1"
+    }
   },
   "prettier": {
     "arrowParens": "always",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/core": "7.18.10",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-flow": "7.18.6",
+    "babel-plugin-module-resolver": "^4.1.0",
     "codecov": "3.8.3",
     "flow-bin": "^0.184.0",
     "husky": "8.0.1",
@@ -82,6 +83,18 @@
         }
       ],
       "@babel/preset-flow"
+    ],
+    "plugins": [
+      [
+        "module-resolver",
+        {
+          "alias": {
+            "@utils": "./src/utils",
+            "@commands": "./src/commands",
+            "@constants": "./src/constants"
+          }
+        }
+      ]
     ]
   },
   "jest": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,8 +5,8 @@ import updateNotifier from 'update-notifier'
 
 import pkg from '../package.json'
 import commands from './commands'
-import FLAGS from './constants/flags'
-import findGitmojiCommand from './utils/findGitmojiCommand'
+import FLAGS from '@constants/flags'
+import findGitmojiCommand from '@utils/findGitmojiCommand'
 
 updateNotifier({ pkg }).notify({ isGlobal: true })
 

--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -1,14 +1,14 @@
 // @flow
 import inquirer from 'inquirer'
 
-import getEmojis from '../../utils/getEmojis'
-import prompts from './prompts'
-import COMMIT_MODES from '../../constants/commit'
+import getEmojis from '@utils/getEmojis'
+import COMMIT_MODES from '@constants/commit'
 import withHook, {
   registerHookInterruptionHandler,
   cancelIfNeeded
 } from './withHook'
 import withClient from './withClient'
+import prompts from './prompts'
 
 export type CommitOptions = {
   message?: string,

--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -1,9 +1,9 @@
 // @flow
 import inquirer from 'inquirer'
 
-import configurationVault from '../../utils/configurationVault'
-import filterGitmojis from '../../utils/filterGitmojis'
-import getDefaultCommitContent from '../../utils/getDefaultCommitContent'
+import configurationVault from '@utils/configurationVault'
+import filterGitmojis from '@utils/filterGitmojis'
+import getDefaultCommitContent from '@utils/getDefaultCommitContent'
 import { type CommitOptions } from './index'
 import guard from './guard'
 
@@ -25,7 +25,10 @@ export type Answers = {
   message: string
 }
 
-export default (gitmojis: Array<Gitmoji>, options: CommitOptions): Array<Object> => {
+export default (
+  gitmojis: Array<Gitmoji>,
+  options: CommitOptions
+): Array<Object> => {
   const { title, message, scope } = getDefaultCommitContent(options)
 
   return [

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -3,8 +3,8 @@ import execa from 'execa'
 import fs from 'fs'
 import chalk from 'chalk'
 
-import isHookCreated from '../../../utils/isHookCreated'
-import configurationVault from '../../../utils/configurationVault'
+import isHookCreated from '@utils/isHookCreated'
+import configurationVault from '@utils/configurationVault'
 import { type Answers } from '../prompts'
 
 const withClient = async (answers: Answers): Promise<void> => {

--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -2,7 +2,7 @@
 import inquirer from 'inquirer'
 
 import configurationPrompts, { CONFIGURATION_PROMPT_NAMES } from './prompts'
-import configurationVault from '../../utils/configurationVault'
+import configurationVault from '@utils/configurationVault'
 
 const config = () => {
   inquirer.prompt(configurationPrompts()).then((answers) => {

--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -1,5 +1,5 @@
 // @flow
-import configurationVault from '../../utils/configurationVault'
+import configurationVault from '@utils/configurationVault'
 
 export const CONFIGURATION_PROMPT_NAMES = {
   AUTO_ADD: 'autoAdd',

--- a/src/commands/hook/create/index.js
+++ b/src/commands/hook/create/index.js
@@ -2,8 +2,8 @@
 import fs from 'fs'
 import ora from 'ora'
 
+import getAbsoluteHooksPath from '@utils/getAbsoluteHooksPath'
 import HOOK from '../hook'
-import getAbsoluteHooksPath from '../../../utils/getAbsoluteHooksPath'
 
 const createHook = async () => {
   const spinner = ora('Creating the gitmoji commit hook').start()

--- a/src/commands/hook/remove/index.js
+++ b/src/commands/hook/remove/index.js
@@ -2,8 +2,8 @@
 import fs from 'fs'
 import ora from 'ora'
 
+import getAbsoluteHooksPath from '@utils/getAbsoluteHooksPath'
 import HOOK from '../hook'
-import getAbsoluteHooksPath from '../../../utils/getAbsoluteHooksPath'
 
 const removeHook = async () => {
   const spinner = ora('Creating the gitmoji commit hook').start()

--- a/src/commands/list/index.js
+++ b/src/commands/list/index.js
@@ -1,6 +1,6 @@
 // @flow
-import getEmojis from '../../utils/getEmojis'
-import printEmojis from '../../utils/printEmojis'
+import getEmojis from '@utils/getEmojis'
+import printEmojis from '@utils/printEmojis'
 
 const list = (): Promise<void> =>
   getEmojis().then((gitmojis) => printEmojis(gitmojis))

--- a/src/commands/search/index.js
+++ b/src/commands/search/index.js
@@ -1,7 +1,7 @@
 // @flow
-import filterGitmojis from '../../utils/filterGitmojis'
-import getEmojis from '../../utils/getEmojis'
-import printEmojis from '../../utils/printEmojis'
+import filterGitmojis from '@utils/filterGitmojis'
+import getEmojis from '@utils/getEmojis'
+import printEmojis from '@utils/printEmojis'
 
 const search = (query: string): Promise<void> => {
   return getEmojis()

--- a/src/commands/update/index.js
+++ b/src/commands/update/index.js
@@ -1,6 +1,6 @@
 // @flow
-import getEmojis from '../../utils/getEmojis'
-import printEmojis from '../../utils/printEmojis'
+import getEmojis from '@utils/getEmojis'
+import printEmojis from '@utils/printEmojis'
 
 const update = (): Promise<void> =>
   getEmojis(true).then((gitmojis) => printEmojis(gitmojis))

--- a/src/utils/configurationVault.js
+++ b/src/utils/configurationVault.js
@@ -4,7 +4,7 @@ import Conf from 'conf'
 import {
   CONFIGURATION_PROMPT_NAMES,
   EMOJI_COMMIT_FORMATS
-} from '../commands/config/prompts'
+} from '@commands/config/prompts'
 
 export const config: typeof Conf = new Conf({ projectName: 'gitmoji' })
 

--- a/src/utils/filterGitmojis.js
+++ b/src/utils/filterGitmojis.js
@@ -1,7 +1,7 @@
 // @flow
 import Fuse from 'fuse.js'
 
-import { type Gitmoji } from '../commands/commit/prompts'
+import { type Gitmoji } from '@commands/commit/prompts'
 
 export const options = {
   threshold: 0.5,

--- a/src/utils/findGitmojiCommand.js
+++ b/src/utils/findGitmojiCommand.js
@@ -1,6 +1,6 @@
 // @flow
-import COMMIT_MODES from '../constants/commit'
-import FLAGS from '../constants/flags'
+import COMMIT_MODES from '@constants/commit'
+import FLAGS from '@constants/flags'
 
 const getOptionsForCommand = (command: ?string, flags: Object): ?Object => {
   const commandsWithOptions = [FLAGS.COMMIT, FLAGS.HOOK]

--- a/src/utils/getDefaultCommitContent.js
+++ b/src/utils/getDefaultCommitContent.js
@@ -1,8 +1,8 @@
 // @flow
 import fs from 'fs'
 
-import { type CommitOptions } from '../commands/commit/index'
-import COMMIT_MODES from '../constants/commit'
+import { type CommitOptions } from '@commands/commit/index'
+import COMMIT_MODES from '@constants/commit'
 
 const COMMIT_FILE_PATH_INDEX = 3
 const COMMIT_TITLE_LINE_INDEX = 0

--- a/src/utils/isHookCreated.js
+++ b/src/utils/isHookCreated.js
@@ -1,7 +1,7 @@
 // @flow
 import fs from 'fs'
 
-import HOOK from '../commands/hook/hook'
+import HOOK from '@commands/hook/hook'
 import getAbsoluteHooksPath from './getAbsoluteHooksPath'
 
 const isHookCreated = async (): Promise<?boolean> => {

--- a/test/commands/commands.spec.js
+++ b/test/commands/commands.spec.js
@@ -1,4 +1,4 @@
-import commands from '../../src/commands'
+import commands from '@commands'
 
 describe('commands', () => {
   it('should match commands', () => {

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -4,20 +4,20 @@ import fs from 'fs'
 import chalk from 'chalk'
 const mockProcess = require('jest-mock-process')
 
-import configurationVault from '../../src/utils/configurationVault'
-import getDefaultCommitContent from '../../src/utils/getDefaultCommitContent'
-import getEmojis from '../../src/utils/getEmojis'
-import isHookCreated from '../../src/utils/isHookCreated'
-import commit from '../../src/commands/commit'
-import guard from '../../src/commands/commit/guard'
-import prompts from '../../src/commands/commit/prompts'
+import configurationVault from '@utils/configurationVault'
+import getDefaultCommitContent from '@utils/getDefaultCommitContent'
+import getEmojis from '@utils/getEmojis'
+import isHookCreated from '@utils/isHookCreated'
+import commit from '@commands/commit'
+import guard from '@commands/commit/guard'
+import prompts from '@commands/commit/prompts'
 import * as stubs from './stubs'
-import { COMMIT_MESSAGE_SOURCE } from '../../src/commands/commit/withHook/index'
+import { COMMIT_MESSAGE_SOURCE } from '@commands/commit/withHook/index'
 
-jest.mock('../../src/utils/getDefaultCommitContent')
-jest.mock('../../src/utils/getEmojis')
-jest.mock('../../src/utils/isHookCreated')
-jest.mock('../../src/utils/configurationVault')
+jest.mock('@utils/getDefaultCommitContent')
+jest.mock('@utils/getEmojis')
+jest.mock('@utils/isHookCreated')
+jest.mock('@utils/configurationVault')
 
 describe('commit command', () => {
   describe('withClient', () => {

--- a/test/commands/config.spec.js
+++ b/test/commands/config.spec.js
@@ -1,11 +1,11 @@
 import inquirer from 'inquirer'
 
-import config from '../../src/commands/config'
-import configurationPrompts from '../../src/commands/config/prompts'
-import configurationVault from '../../src/utils/configurationVault'
+import config from '@commands/config'
+import configurationPrompts from '@commands/config/prompts'
+import configurationVault from '@utils/configurationVault'
 import * as stubs from './stubs'
 
-jest.mock('../../src/utils/configurationVault')
+jest.mock('@utils/configurationVault')
 
 describe('config command', () => {
   beforeAll(() => {

--- a/test/commands/hook.spec.js
+++ b/test/commands/hook.spec.js
@@ -1,11 +1,11 @@
 import fs from 'fs'
 
-import hook from '../../src/commands/hook'
-import hookConfig from '../../src/commands/hook/hook'
-import getAbsoluteHooksPath from '../../src/utils/getAbsoluteHooksPath'
+import hook from '@commands/hook'
+import hookConfig from '@commands/hook/hook'
+import getAbsoluteHooksPath from '@utils/getAbsoluteHooksPath'
 import * as stubs from './stubs'
 
-jest.mock('../../src/utils/getAbsoluteHooksPath')
+jest.mock('@utils/getAbsoluteHooksPath')
 
 describe('hook command', () => {
   beforeAll(() => {

--- a/test/commands/list.spec.js
+++ b/test/commands/list.spec.js
@@ -1,11 +1,11 @@
-import getEmojis from '../../src/utils/getEmojis'
-import printEmojis from '../../src/utils/printEmojis'
-import list from '../../src/commands/list'
+import getEmojis from '@utils/getEmojis'
+import printEmojis from '@utils/printEmojis'
+import list from '@commands/list'
 
 import * as stubs from './stubs'
 
-jest.mock('../../src/utils/getEmojis')
-jest.mock('../../src/utils/printEmojis')
+jest.mock('@utils/getEmojis')
+jest.mock('@utils/printEmojis')
 
 describe('list command', () => {
   beforeAll(() => {

--- a/test/commands/search.spec.js
+++ b/test/commands/search.spec.js
@@ -1,11 +1,11 @@
-import getEmojis from '../../src/utils/getEmojis'
-import printEmojis from '../../src/utils/printEmojis'
-import search from '../../src/commands/search'
+import getEmojis from '@utils/getEmojis'
+import printEmojis from '@utils/printEmojis'
+import search from '@commands/search'
 
 import * as stubs from './stubs'
 
-jest.mock('../../src/utils/getEmojis')
-jest.mock('../../src/utils/printEmojis')
+jest.mock('@utils/getEmojis')
+jest.mock('@utils/printEmojis')
 
 describe('search command', () => {
   beforeAll(() => {

--- a/test/commands/update.spec.js
+++ b/test/commands/update.spec.js
@@ -1,11 +1,11 @@
-import getEmojis from '../../src/utils/getEmojis'
-import printEmojis from '../../src/utils/printEmojis'
-import update from '../../src/commands/update'
+import getEmojis from '@utils/getEmojis'
+import printEmojis from '@utils/printEmojis'
+import update from '@commands/update'
 
 import * as stubs from './stubs'
 
-jest.mock('../../src/utils/getEmojis')
-jest.mock('../../src/utils/printEmojis')
+jest.mock('@utils/getEmojis')
+jest.mock('@utils/printEmojis')
 
 describe('update command', () => {
   beforeAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,6 +1662,17 @@ babel-plugin-jest-hoist@^28.1.3:
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-module-resolver@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz#22a4f32f7441727ec1fbf4967b863e1e3e9f33e2"
+  integrity sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==
+  dependencies:
+    find-babel-config "^1.2.0"
+    glob "^7.1.6"
+    pkg-up "^3.1.0"
+    reselect "^4.0.0"
+    resolve "^1.13.1"
+
 babel-plugin-polyfill-corejs2@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz#e4c31d4c89b56f3cf85b92558954c66b54bd972d"
@@ -2466,6 +2477,14 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -2623,7 +2642,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
+glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -2930,6 +2949,13 @@ is-core-module@2.9.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -3514,6 +3540,11 @@ json-schema-typed@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-7.0.3.tgz#23ff481b8b4eebcd2ca123b4fa0409e66469a2d9"
   integrity sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==
+
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
 
 json5@^2.2.1:
   version "2.2.1"
@@ -4503,6 +4534,11 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+reselect@^4.0.0:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.6.tgz#19ca2d3d0b35373a74dc1c98692cdaffb6602656"
+  integrity sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -4526,6 +4562,15 @@ resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.2
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
     is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.13.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR replaces `./` imports with the `babel-plugin-module-resolver` so we can import everything using `@`.
