### PR TITLE
🔥 Remove signed commits option from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,4 @@ Run `gitmoji -g` to setup some gitmoji-cli preferences.
 - **Automatic git add**: Enable or disable the automatic `git add .` every time you use the commit command.
 - **Emoji format**: Switch between the emoji format.
 - **Scope prompt**: Enable or disable [conventional commits scope prompt](https://www.conventionalcommits.org/en/v1.0.0/#summary).
-- **Signed commits**: Enable or disable [signed commits with GPG](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/signing-commits).
 - **Gitmojis api URL**: Set a custom URL to use it as the library of gitmojis.

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -11,7 +11,6 @@ const withClient = async (answers: Answers): Promise<void> => {
   try {
     const scope = answers.scope ? `(${answers.scope}): ` : ''
     const title = `${answers.gitmoji} ${scope}${answers.title}`
-    const isSigned = configurationVault.getSignedCommit() ? ['-S'] : []
 
     if (await isHookCreated()) {
       return console.log(
@@ -26,14 +25,10 @@ const withClient = async (answers: Answers): Promise<void> => {
 
     if (configurationVault.getAutoAdd()) await execa('git', ['add', '.'])
 
-    await execa(
-      'git',
-      ['commit', ...isSigned, '-m', title, '-m', answers.message],
-      {
-        buffer: false,
-        stdio: 'inherit'
-      }
-    )
+    await execa('git', ['commit', '-m', title, '-m', answers.message], {
+      buffer: false,
+      stdio: 'inherit'
+    })
   } catch (error) {
     console.error(
       chalk.red(

--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -10,9 +10,6 @@ const config = () => {
     configurationVault.setEmojiFormat(
       answers[CONFIGURATION_PROMPT_NAMES.EMOJI_FORMAT]
     )
-    configurationVault.setSignedCommit(
-      answers[CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT]
-    )
     configurationVault.setScopePrompt(
       answers[CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT]
     )

--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -5,7 +5,6 @@ export const CONFIGURATION_PROMPT_NAMES = {
   AUTO_ADD: 'autoAdd',
   EMOJI_FORMAT: 'emojiFormat',
   SCOPE_PROMPT: 'scopePrompt',
-  SIGNED_COMMIT: 'signedCommit',
   GITMOJIS_URL: 'gitmojisUrl'
 }
 
@@ -30,12 +29,6 @@ export default (): Array<Object> => [
       { name: '😄', value: EMOJI_COMMIT_FORMATS.EMOJI }
     ],
     default: configurationVault.getEmojiFormat()
-  },
-  {
-    name: CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT,
-    message: 'Enable signed commits',
-    type: 'confirm',
-    default: configurationVault.getSignedCommit()
   },
   {
     name: CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT,

--- a/src/utils/configurationVault.js
+++ b/src/utils/configurationVault.js
@@ -13,7 +13,6 @@ export const config: typeof Conf = new Conf({
     [CONFIGURATION_PROMPT_NAMES.EMOJI_FORMAT]: {
       enum: Object.values(EMOJI_COMMIT_FORMATS)
     },
-    [CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT]: { type: 'boolean' },
     [CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT]: { type: 'boolean' },
     [CONFIGURATION_PROMPT_NAMES.GITMOJIS_URL]: { type: 'string', format: 'url' }
   }
@@ -25,10 +24,6 @@ const setAutoAdd = (autoAdd: boolean): void => {
 
 const setEmojiFormat = (emojiFormat: string): void => {
   config.set(CONFIGURATION_PROMPT_NAMES.EMOJI_FORMAT, emojiFormat)
-}
-
-const setSignedCommit = (signedCommit: boolean): void => {
-  config.set(CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT, signedCommit)
 }
 
 const setScopePrompt = (scopePrompt: boolean): void => {
@@ -50,10 +45,6 @@ const getEmojiFormat = (): string => {
   )
 }
 
-const getSignedCommit = (): boolean => {
-  return config.get(CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT) || false
-}
-
 const getScopePrompt = (): boolean => {
   return config.get(CONFIGURATION_PROMPT_NAMES.SCOPE_PROMPT) || false
 }
@@ -68,11 +59,9 @@ export default {
   getAutoAdd,
   getEmojiFormat,
   getScopePrompt,
-  getSignedCommit,
   getGitmojisUrl,
   setAutoAdd,
   setEmojiFormat,
   setScopePrompt,
-  setSignedCommit,
   setGitmojisUrl
 }

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -66,7 +66,6 @@ describe('commit command', () => {
         getEmojis.mockResolvedValue(stubs.gitmojis)
         isHookCreated.mockResolvedValue(false)
         configurationVault.getAutoAdd.mockReturnValue(true)
-        configurationVault.getSignedCommit.mockReturnValue(true)
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent
         )
@@ -86,7 +85,6 @@ describe('commit command', () => {
           'git',
           [
             'commit',
-            '-S',
             '-m',
             `${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}`,
             '-m',
@@ -133,7 +131,6 @@ describe('commit command', () => {
         getEmojis.mockResolvedValue(stubs.gitmojis)
         isHookCreated.mockResolvedValue(false)
         configurationVault.getAutoAdd.mockReturnValue(true)
-        configurationVault.getSignedCommit.mockReturnValue(true)
         getDefaultCommitContent.mockReturnValueOnce(
           stubs.emptyDefaultCommitContent
         )

--- a/test/commands/config.spec.js
+++ b/test/commands/config.spec.js
@@ -24,9 +24,6 @@ describe('config command', () => {
     expect(configurationVault.setEmojiFormat).toHaveBeenCalledWith(
       stubs.configAnswers.emojiFormat
     )
-    expect(configurationVault.setSignedCommit).toHaveBeenCalledWith(
-      stubs.configAnswers.signedCommit
-    )
     expect(configurationVault.setScopePrompt).toHaveBeenCalledWith(
       stubs.configAnswers.scopePrompt
     )

--- a/test/utils/__snapshots__/configurationVault.spec.js.snap
+++ b/test/utils/__snapshots__/configurationVault.spec.js.snap
@@ -6,11 +6,9 @@ Object {
   "getEmojiFormat": [Function],
   "getGitmojisUrl": [Function],
   "getScopePrompt": [Function],
-  "getSignedCommit": [Function],
   "setAutoAdd": [Function],
   "setEmojiFormat": [Function],
   "setGitmojisUrl": [Function],
   "setScopePrompt": [Function],
-  "setSignedCommit": [Function],
 }
 `;

--- a/test/utils/configurationVault.spec.js
+++ b/test/utils/configurationVault.spec.js
@@ -22,10 +22,6 @@ describe('configurationVault', () => {
       expect(configurationVault.getEmojiFormat()).toEqual('code')
     })
 
-    it('should return the default value for signedCommit', () => {
-      expect(configurationVault.getSignedCommit()).toEqual(false)
-    })
-
     it('should return the default value for scopePrompt', () => {
       expect(configurationVault.getScopePrompt()).toEqual(false)
     })
@@ -71,20 +67,7 @@ describe('configurationVault', () => {
       )
     })
 
-    it('should set and return value for signedCommit', () => {
-      configurationVault.setSignedCommit(true)
-      configurationVault.getSignedCommit()
-
-      expect(config.set).toHaveBeenCalledWith(
-        CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT,
-        true
-      )
-      expect(config.get).toHaveBeenCalledWith(
-        CONFIGURATION_PROMPT_NAMES.SIGNED_COMMIT
-      )
-    })
-
-    it('should set and return value for signedCommit', () => {
+    it('should set and return value for scopePrompt', () => {
       configurationVault.setScopePrompt(true)
       configurationVault.getScopePrompt()
 


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR removes the `signedCommit` option from the cli as this can be controlled with `.gitconfig`:

```
$ git config --global commit.gpgsign true
```