### PR TITLE
✏️ Fix comma typo in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ If no user configuration is found, a set of default values will be used.
   "gitmoji": {
     "autoAdd": false,
     "emojiFormat": "code | emoji",
-    "scopePrompt": false
-    "gitmojisUrl": "https://gitmoji.dev/api/gitmojis",
+    "scopePrompt": false,
+    "gitmojisUrl": "https://gitmoji.dev/api/gitmojis"
   }
 }
 ```


### PR DESCRIPTION
## Description

- There is a typo in the README.md and it has been corrected, so please check if it is OK.
  - Commas were misplaced in the example description of package.json in README.md.

I didn't create an issue for fixing typos

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
