### PR TITLE
♻️ Migrate from require to readFileSync in configurationVault

### DIFF
--- a/src/utils/configurationVault/getConfiguration.js
+++ b/src/utils/configurationVault/getConfiguration.js
@@ -1,5 +1,6 @@
 import Conf from 'conf'
 import { cwd } from 'process'
+import { readFileSync } from 'fs'
 import { pathExistsSync } from 'path-exists'
 
 import { CONFIG, EMOJI_COMMIT_FORMATS } from '@constants/configuration'
@@ -30,12 +31,14 @@ const getConfiguration = (): { get: Function, set: Function } => {
     const packageJson = `${cwd()}/package.json`
     const configurationFile = `${cwd()}/.gitmojirc.json`
 
-    if (pathExistsSync(packageJson) && require(packageJson)?.gitmoji) {
-      return require(packageJson).gitmoji
+    if (pathExistsSync(packageJson)) {
+      const config = JSON.parse(readFileSync(packageJson))?.gitmoji
+      if (config) return config
     }
 
-    if (pathExistsSync(configurationFile) && require(configurationFile)) {
-      return require(configurationFile)
+    if (pathExistsSync(configurationFile)) {
+      const config = JSON.parse(readFileSync(configurationFile))
+      if (config) return config
     }
 
     return LOCAL_CONFIGURATION.store

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -2,7 +2,7 @@ import inquirer from 'inquirer'
 import { execa } from 'execa'
 import fs from 'fs'
 import chalk from 'chalk'
-const mockProcess = require('jest-mock-process')
+import { mockProcessExit } from 'jest-mock-process'
 
 import configurationVault from '@utils/configurationVault'
 import getDefaultCommitContent from '@utils/getDefaultCommitContent'
@@ -162,7 +162,7 @@ describe('commit command', () => {
           Promise.resolve(stubs.clientCommitAnswers)
         )
         getEmojis.mockResolvedValue(stubs.gitmojis)
-        mockProcess.mockProcessExit()
+        mockProcessExit()
         process.argv[3] = stubs.argv
         process.argv[COMMIT_MESSAGE_SOURCE] = undefined
         getDefaultCommitContent.mockReturnValueOnce(
@@ -192,7 +192,7 @@ describe('commit command', () => {
           Promise.resolve(stubs.clientCommitAnswersWithScope)
         )
         getEmojis.mockResolvedValue(stubs.gitmojis)
-        mockProcess.mockProcessExit()
+        mockProcessExit()
         process.argv[3] = stubs.argv
         process.argv[COMMIT_MESSAGE_SOURCE] = stubs.commitSource
         getDefaultCommitContent.mockReturnValueOnce(
@@ -223,7 +223,7 @@ describe('commit command', () => {
         Simulation needed because if we just mock process exit, then the code execution resume in the test.
         */
         process.argv[COMMIT_MESSAGE_SOURCE] = stubs.commitSource
-        mockProcess.mockProcessExit(new Error('ProcessExit0'))
+        mockProcessExit(new Error('ProcessExit0'))
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         // mock that we found one of the rebase trigger (file existence in .git)
         fs.existsSync.mockReturnValueOnce(true)
@@ -245,7 +245,7 @@ describe('commit command', () => {
         when the hook mode detect that the user is rebasing. (Simulated to not kill the tests)
         Simulation needed because if we just mock process exit, then the code execution resume in the test.
         */
-        mockProcess.mockProcessExit(new Error('ProcessExit0'))
+        mockProcessExit(new Error('ProcessExit0'))
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         // mock that we are amending
         process.argv[COMMIT_MESSAGE_SOURCE] = 'commit sha123'
@@ -282,7 +282,7 @@ describe('commit command', () => {
         getEmojis.mockResolvedValue(stubs.gitmojis)
 
         // Use an exception to suspend code execution to simulate process.exit
-        mockProcess.mockProcessExit(new Error('SIGINT'))
+        mockProcessExit(new Error('SIGINT'))
         process.argv[3] = stubs.argv
         process.argv[COMMIT_MESSAGE_SOURCE] = stubs.commitSource
 
@@ -303,7 +303,7 @@ describe('commit command', () => {
 
     describe('with git auto merge trigger by git pull', () => {
       it('should cancel the hook', async () => {
-        mockProcess.mockProcessExit(new Error('ProcessExit0'))
+        mockProcessExit(new Error('ProcessExit0'))
         execa.mockReturnValueOnce(Promise.resolve(stubs.gitAbsoluteDir))
         // mock that we are merging
         process.argv[3] = '.git/MERGE_MSG'
@@ -318,7 +318,6 @@ describe('commit command', () => {
         expect(process.exit).toHaveBeenCalledWith(0)
       })
     })
-
   })
 
   describe('guard', () => {

--- a/test/utils/buildFetchOptions.spec.js
+++ b/test/utils/buildFetchOptions.spec.js
@@ -103,11 +103,12 @@ describe('buildFetchOptions', () => {
 
     describe('when using an anonymous proxy', () => {
       describe('when is http proxy', () => {
-        it('should return an object containing a proxy agent', () => {
+        it('should return an object containing a proxy agent', async () => {
           process.env.http_proxy = 'http://localhost-env:8080'
 
-          const buildFetchOptionsFromEnv = require('../../src/utils/buildFetchOptions')
-            .default
+          const { default: buildFetchOptionsFromEnv } = await import(
+            '../../src/utils/buildFetchOptions'
+          )
 
           expect(buildFetchOptionsFromEnv()).toMatchObject({
             agent: {
@@ -126,11 +127,12 @@ describe('buildFetchOptions', () => {
       })
 
       describe('when is https proxy', () => {
-        it('should return an object containing a proxy agent', () => {
+        it('should return an object containing a proxy agent', async () => {
           process.env.https_proxy = 'https://localhost-env:8080'
 
-          const buildFetchOptionsFromEnv = require('../../src/utils/buildFetchOptions')
-            .default
+          const { default: buildFetchOptionsFromEnv } = await import(
+            '../../src/utils/buildFetchOptions'
+          )
 
           expect(buildFetchOptionsFromEnv()).toMatchObject({
             agent: {
@@ -151,11 +153,12 @@ describe('buildFetchOptions', () => {
 
     describe('when using an authenticated proxy', () => {
       describe('when is http proxy', () => {
-        it('should return an object containing a proxy agent', () => {
+        it('should return an object containing a proxy agent', async () => {
           process.env.http_proxy = 'http://user:pass@localhost-env:8080'
 
-          const buildFetchOptionsFromEnv = require('../../src/utils/buildFetchOptions')
-            .default
+          const { default: buildFetchOptionsFromEnv } = await import(
+            '../../src/utils/buildFetchOptions'
+          )
 
           expect(buildFetchOptionsFromEnv()).toMatchObject({
             agent: {
@@ -174,11 +177,12 @@ describe('buildFetchOptions', () => {
       })
 
       describe('when is https proxy', () => {
-        it('should return an object containing a proxy agent', () => {
+        it('should return an object containing a proxy agent', async () => {
           process.env.https_proxy = 'https://user:pass@localhost-env:8080'
 
-          const buildFetchOptionsFromEnv = require('../../src/utils/buildFetchOptions')
-            .default
+          const { default: buildFetchOptionsFromEnv } = await import(
+            '../../src/utils/buildFetchOptions'
+          )
 
           expect(buildFetchOptionsFromEnv()).toMatchObject({
             agent: {

--- a/test/utils/configurationVault/getConfiguration.spec.js
+++ b/test/utils/configurationVault/getConfiguration.spec.js
@@ -1,13 +1,16 @@
 import Conf from 'conf'
+import { readFileSync } from 'fs'
 import { pathExistsSync } from 'path-exists'
 
 import { CONFIG, EMOJI_COMMIT_FORMATS } from '@constants/configuration'
 import getConfiguration from '@utils/configurationVault/getConfiguration'
 
-jest.mock('conf', () => jest.fn().mockReturnValue({
-  store: { from: 'local-cli' },
-  set: jest.fn()
-}))
+jest.mock('conf', () =>
+  jest.fn().mockReturnValue({
+    store: { from: 'local-cli' },
+    set: jest.fn()
+  })
+)
 
 describe('getConfiguration', () => {
   describe('setup', () => {
@@ -40,9 +43,9 @@ describe('getConfiguration', () => {
 
       describe('when `gitmoji` key is defined', () => {
         beforeAll(() => {
-          jest.doMock('../../../package.json', () => ({
-            gitmoji: { from: 'package.json' }
-          }))
+          readFileSync.mockImplementation(() =>
+            JSON.stringify({ gitmoji: { from: 'package.json' } })
+          )
         })
 
         it('should return package.json configuration', () => {
@@ -54,9 +57,7 @@ describe('getConfiguration', () => {
 
       describe('when `gitmoji` key is not defined', () => {
         beforeAll(() => {
-          jest.doMock('../../../package.json', () => ({
-            gitmoji: undefined
-          }))
+          readFileSync.mockImplementation(() => JSON.stringify({}))
         })
 
         it('should return local configuration', () => {
@@ -80,9 +81,7 @@ describe('getConfiguration', () => {
 
       describe('when file contains a valid json', () => {
         beforeAll(() => {
-          jest.doMock('../../../.gitmojirc.json', () => ({
-            from: 'rc'
-          }), { virtual: true })
+          readFileSync.mockImplementation(() => JSON.stringify({ from: 'rc' }))
         })
 
         it('should return .gitmojirc.json configuration', () => {
@@ -94,7 +93,7 @@ describe('getConfiguration', () => {
 
       describe('when file is empty', () => {
         beforeAll(() => {
-          jest.doMock('../../../.gitmojirc.json', () => undefined, { virtual: true })
+          readFileSync.mockImplementation(() => JSON.stringify(null))
         })
 
         it('should return .gitmojirc.json configuration', () => {


### PR DESCRIPTION
## Description

1. Migrate from `require` to `readFileSync` as described in https://github.com/carloscuesta/gitmoji-cli/pull/926#pullrequestreview-1122464804.
2. Migrate from `require` to `import` statements for `mockProcessExit` in unit tests.
3. Migrate from `require` to dynamic `import` for `buildFetchOptions` unit tests.

## Tests

- [x] All tests passed.
