### PR TITLE
🔧 Enable `dependabot` for GitHub Action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    open-pull-requests-limit: 10
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "04:00"
-  labels:
-      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "04:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
     interval: weekly
     time: "04:00"
   open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "04:00"
+  labels:
+      - "dependencies"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR enables dependabot for GitHub Action dependencies.