### PR TITLE
🚸 Improve error message when doing commits

### DIFF
--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -22,18 +22,13 @@ const withClient = async (answers: Answers): Promise<void> => {
         )
       )
     }
+    const autoAdd = configurationVault.getAutoAdd()
 
-    if (configurationVault.getAutoAdd()) await execa('git', ['add', '.'])
+    if (autoAdd) await execa('git', ['add', '.'])
 
     await execa(
       'git',
-      [
-        'commit',
-        configurationVault.getAutoAdd() ? '-am' : '-m',
-        title,
-        '-m',
-        answers.message
-      ],
+      ['commit', autoAdd ? '-am' : '-m', title, '-m', answers.message],
       {
         buffer: false,
         stdio: 'inherit'

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -25,10 +25,20 @@ const withClient = async (answers: Answers): Promise<void> => {
 
     if (configurationVault.getAutoAdd()) await execa('git', ['add', '.'])
 
-    await execa('git', ['commit', '-m', title, '-m', answers.message], {
-      buffer: false,
-      stdio: 'inherit'
-    })
+    await execa(
+      'git',
+      [
+        'commit',
+        configurationVault.getAutoAdd() ? '-am' : '-m',
+        title,
+        '-m',
+        answers.message
+      ],
+      {
+        buffer: false,
+        stdio: 'inherit'
+      }
+    )
   } catch (error) {
     console.error(
       chalk.red(

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -11,6 +11,7 @@ const withClient = async (answers: Answers): Promise<void> => {
   try {
     const scope = answers.scope ? `(${answers.scope}): ` : ''
     const title = `${answers.gitmoji} ${scope}${answers.title}`
+    const isAutoAddEnabled = configurationVault.getAutoAdd()
 
     if (await isHookCreated()) {
       return console.log(
@@ -22,13 +23,12 @@ const withClient = async (answers: Answers): Promise<void> => {
         )
       )
     }
-    const autoAdd = configurationVault.getAutoAdd()
 
-    if (autoAdd) await execa('git', ['add', '.'])
+    if (isAutoAddEnabled) await execa('git', ['add', '.'])
 
     await execa(
       'git',
-      ['commit', autoAdd ? '-am' : '-m', title, '-m', answers.message],
+      ['commit', isAutoAddEnabled ? '-am' : '-m', title, '-m', answers.message],
       {
         buffer: false,
         stdio: 'inherit'

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -85,7 +85,7 @@ describe('commit command', () => {
           'git',
           [
             'commit',
-            '-m',
+            '-am',
             `${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}`,
             '-m',
             stubs.clientCommitAnswersWithScope.message


### PR DESCRIPTION
This PR adjusts the command sent for `gitmoji -c` when the `automatically add` is enabled.

Before: if the command failed, it would return a retry command without the `a` preventing the very simply copy+paste to resume after a failure.

Now it will return that in the error when that setting is enabled.