### PR TITLE
💥 Bump minimum `node` version to `>=16`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "A gitmoji client for using emojis on commit messages.",
   "engines": {
-    "node": ">=14.16"
+    "node": ">=16"
   },
   "bin": {
     "gitmoji": "lib/cli.js"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

Node.js v14 end of life is coming soon and we need to bump the requirements for the `cli`.

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
