### PR TITLE
:bug: (hooks) fix bug for npx -c call

### DIFF
--- a/src/commands/hook/hook.js
+++ b/src/commands/hook/hook.js
@@ -6,7 +6,7 @@ const HOOK: Object = {
     '#!/usr/bin/env sh\n# gitmoji as a commit hook\n' +
     'if npx -v >&/dev/null\n' +
     'then\n' +
-    '  exec < /dev/tty\n  npx -c gitmoji --hook $1 $2\n' +
+    '  exec < /dev/tty\n  npx -c "gitmoji --hook $1 $2"\n' +
     'else\n' +
     '  exec < /dev/tty\n  gitmoji --hook $1 $2\n' +
     'fi'

--- a/test/commands/__snapshots__/hook.spec.js.snap
+++ b/test/commands/__snapshots__/hook.spec.js.snap
@@ -7,7 +7,7 @@ exports[`hook command should match hook configuration 1`] = `
 if npx -v >&/dev/null
 then
   exec < /dev/tty
-  npx -c gitmoji --hook $1 $2
+  npx -c "gitmoji --hook $1 $2"
 else
   exec < /dev/tty
   gitmoji --hook $1 $2


### PR DESCRIPTION
with the -c option the cmd and the args must be within quotes

## Description

With #1039 and the `-c` option the needed quotes for `-c` are missing

Issue: #

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
