### PR TITLE
✨ Allow user to disable message prompt

### DIFF
--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -66,10 +66,14 @@ export default (
       },
       ...(title ? { default: title } : {})
     },
-    {
-      name: 'message',
-      message: 'Enter the commit message:',
-      ...(message ? { default: message } : {})
-    }
+    ...(configurationVault.getMessagePrompt()
+      ? [
+          {
+            name: 'message',
+            message: 'Enter the commit message:',
+            ...(message ? { default: message } : {})
+          }
+        ]
+      : [])
   ]
 }

--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -10,6 +10,7 @@ const config = () => {
     configurationVault.setAutoAdd(answers[CONFIG.AUTO_ADD])
     configurationVault.setEmojiFormat(answers[CONFIG.EMOJI_FORMAT])
     configurationVault.setScopePrompt(answers[CONFIG.SCOPE_PROMPT])
+    configurationVault.setMessagePrompt(answers[CONFIG.MESSAGE_PROMPT])
     configurationVault.setGitmojisUrl(answers[CONFIG.GITMOJIS_URL])
   })
 }

--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -27,6 +27,12 @@ export default (): Array<Object> => [
     default: configurationVault.getScopePrompt()
   },
   {
+    name: CONFIG.MESSAGE_PROMPT,
+    message: 'Enable message prompt',
+    type: 'confirm',
+    default: configurationVault.getMessagePrompt()
+  },
+  {
     name: CONFIG.GITMOJIS_URL,
     message: 'Set gitmojis api url',
     type: 'input',

--- a/src/constants/configuration.js
+++ b/src/constants/configuration.js
@@ -2,7 +2,8 @@ export const CONFIG = {
   AUTO_ADD: 'autoAdd',
   EMOJI_FORMAT: 'emojiFormat',
   SCOPE_PROMPT: 'scopePrompt',
-  GITMOJIS_URL: 'gitmojisUrl'
+  GITMOJIS_URL: 'gitmojisUrl',
+  MESSAGE_PROMPT: 'messagePrompt'
 }
 
 export const EMOJI_COMMIT_FORMATS = {

--- a/src/utils/configurationVault/getConfiguration.js
+++ b/src/utils/configurationVault/getConfiguration.js
@@ -16,13 +16,27 @@ const DEFAULT_CONFIGURATION = {
 const LOCAL_CONFIGURATION: typeof Conf = new Conf({
   projectName: 'gitmoji',
   schema: {
-    [CONFIG.AUTO_ADD]: { type: 'boolean' },
-    [CONFIG.EMOJI_FORMAT]: {
-      enum: Object.values(EMOJI_COMMIT_FORMATS)
+    [CONFIG.AUTO_ADD]: {
+      type: 'boolean',
+      default: DEFAULT_CONFIGURATION[CONFIG.AUTO_ADD]
     },
-    [CONFIG.SCOPE_PROMPT]: { type: 'boolean' },
-    [CONFIG.MESSAGE_PROMPT]: { type: 'boolean' },
-    [CONFIG.GITMOJIS_URL]: { type: 'string', format: 'url' }
+    [CONFIG.EMOJI_FORMAT]: {
+      enum: Object.values(EMOJI_COMMIT_FORMATS),
+      default: DEFAULT_CONFIGURATION[CONFIG.EMOJI_FORMAT]
+    },
+    [CONFIG.SCOPE_PROMPT]: {
+      type: 'boolean',
+      default: DEFAULT_CONFIGURATION[CONFIG.SCOPE_PROMPT]
+    },
+    [CONFIG.MESSAGE_PROMPT]: {
+      type: 'boolean',
+      default: DEFAULT_CONFIGURATION[CONFIG.MESSAGE_PROMPT]
+    },
+    [CONFIG.GITMOJIS_URL]: {
+      type: 'string',
+      format: 'url',
+      default: DEFAULT_CONFIGURATION[CONFIG.GITMOJIS_URL]
+    }
   }
 })
 
@@ -61,7 +75,7 @@ const getConfiguration = (): { get: Function, set: Function } => {
           ? resolvedConfiguration
           : DEFAULT_CONFIGURATION
 
-      return configuration[key]
+      return configuration[key] ?? DEFAULT_CONFIGURATION[key]
     },
     set: (key: string, value: string | boolean): void =>
       LOCAL_CONFIGURATION.set(key, value)

--- a/src/utils/configurationVault/getConfiguration.js
+++ b/src/utils/configurationVault/getConfiguration.js
@@ -9,6 +9,7 @@ const DEFAULT_CONFIGURATION = {
   [CONFIG.AUTO_ADD]: false,
   [CONFIG.EMOJI_FORMAT]: EMOJI_COMMIT_FORMATS.CODE,
   [CONFIG.SCOPE_PROMPT]: false,
+  [CONFIG.MESSAGE_PROMPT]: true,
   [CONFIG.GITMOJIS_URL]: 'https://gitmoji.dev/api/gitmojis'
 }
 
@@ -20,6 +21,7 @@ const LOCAL_CONFIGURATION: typeof Conf = new Conf({
       enum: Object.values(EMOJI_COMMIT_FORMATS)
     },
     [CONFIG.SCOPE_PROMPT]: { type: 'boolean' },
+    [CONFIG.MESSAGE_PROMPT]: { type: 'boolean' },
     [CONFIG.GITMOJIS_URL]: { type: 'string', format: 'url' }
   }
 })

--- a/src/utils/configurationVault/index.js
+++ b/src/utils/configurationVault/index.js
@@ -16,6 +16,10 @@ const setScopePrompt = (scopePrompt: boolean): void => {
   configuration.set(CONFIG.SCOPE_PROMPT, scopePrompt)
 }
 
+const setMessagePrompt = (messagePrompt: boolean): void => {
+  configuration.set(CONFIG.MESSAGE_PROMPT, messagePrompt)
+}
+
 const setGitmojisUrl = (gitmojisUrl: string): void => {
   configuration.set(CONFIG.GITMOJIS_URL, gitmojisUrl)
 }
@@ -32,6 +36,10 @@ const getScopePrompt = (): boolean => {
   return configuration.get(CONFIG.SCOPE_PROMPT)
 }
 
+const getMessagePrompt = (): boolean => {
+  return configuration.get(CONFIG.MESSAGE_PROMPT)
+}
+
 const getGitmojisUrl = (): string => {
   return configuration.get(CONFIG.GITMOJIS_URL)
 }
@@ -40,9 +48,11 @@ export default {
   getAutoAdd,
   getEmojiFormat,
   getScopePrompt,
+  getMessagePrompt,
   getGitmojisUrl,
   setAutoAdd,
   setEmojiFormat,
   setScopePrompt,
+  setMessagePrompt,
   setGitmojisUrl
 }

--- a/test/commands/__snapshots__/commit.spec.js.snap
+++ b/test/commands/__snapshots__/commit.spec.js.snap
@@ -238,3 +238,24 @@ exports[`commit command withClient with the commit hook created should call inqu
   ],
 ]
 `;
+
+exports[`commit command prompts without message prompt should match the array of questions 1`] = `
+[
+  {
+    "message": "Choose a gitmoji:",
+    "name": "gitmoji",
+    "source": [Function],
+    "type": "autocomplete",
+  },
+  {
+    "message": "Enter the scope of current changes:",
+    "name": "scope",
+  },
+  {
+    "message": "Enter the commit title",
+    "name": "title",
+    "transformer": [Function],
+    "validate": [Function],
+  },
+]
+`;

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -33,6 +33,7 @@ describe('commit command', () => {
           stubs.emptyDefaultCommitContent
         )
         commit({ mode: 'client' })
+        configurationVault.getMessagePrompt.mockReturnValue(true)
       })
 
       it('should call inquirer with prompts', () => {
@@ -337,6 +338,10 @@ describe('commit command', () => {
   })
 
   describe('prompts', () => {
+    beforeAll(() => {
+      configurationVault.getMessagePrompt.mockReturnValue(true)
+    })
+
     it('should register the autoComplete inquirer prompt', () => {
       expect(inquirer.registerPrompt).toHaveBeenCalledWith(
         'autocomplete',
@@ -388,6 +393,19 @@ describe('commit command', () => {
 
       it('should not fill default title and message', () => {
         expect(prompts(stubs.gitmojis, 'commit')).toMatchSnapshot()
+      })
+    })
+
+    describe('without message prompt', () => {
+      beforeAll(() => {
+        getDefaultCommitContent.mockReturnValueOnce(
+          stubs.emptyDefaultCommitContent
+        )
+        configurationVault.getMessagePrompt.mockReturnValue(false)
+      })
+
+      it('should match the array of questions', () => {
+        expect(prompts(stubs.gitmojis, 'client')).toMatchSnapshot()
       })
     })
   })

--- a/test/commands/config.spec.js
+++ b/test/commands/config.spec.js
@@ -28,6 +28,9 @@ describe('config command', () => {
     expect(configurationVault.setScopePrompt).toHaveBeenCalledWith(
       stubs.configAnswers.scopePrompt
     )
+    expect(configurationVault.setMessagePrompt).toHaveBeenCalledWith(
+      stubs.configAnswers.messagePrompt
+    )
     expect(configurationVault.setGitmojisUrl).toHaveBeenCalledWith(
       stubs.configAnswers.gitmojisUrl
     )

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -22,6 +22,7 @@ export const configAnswers = {
   emojiFormat: 'emoji',
   signedCommit: true,
   scopePrompt: false,
+  messagePrompt: true,
   gitmojisUrl: GITMOJIS_URL
 }
 

--- a/test/utils/configurationVault/__snapshots__/defaults.spec.js.snap
+++ b/test/utils/configurationVault/__snapshots__/defaults.spec.js.snap
@@ -5,10 +5,12 @@ exports[`index should match the module 1`] = `
   "getAutoAdd": [Function],
   "getEmojiFormat": [Function],
   "getGitmojisUrl": [Function],
+  "getMessagePrompt": [Function],
   "getScopePrompt": [Function],
   "setAutoAdd": [Function],
   "setEmojiFormat": [Function],
   "setGitmojisUrl": [Function],
+  "setMessagePrompt": [Function],
   "setScopePrompt": [Function],
 }
 `;

--- a/test/utils/configurationVault/defaults.spec.js
+++ b/test/utils/configurationVault/defaults.spec.js
@@ -18,6 +18,10 @@ describe('index', () => {
       expect(configurationVault.getScopePrompt()).toEqual(false)
     })
 
+    it('should return the default value for messagePrompt', () => {
+      expect(configurationVault.getMessagePrompt()).toEqual(true)
+    })
+
     it('should return the default value for gitmojisUrl', () => {
       expect(configurationVault.getGitmojisUrl()).toEqual(
         'https://gitmoji.dev/api/gitmojis'

--- a/test/utils/configurationVault/getConfiguration.spec.js
+++ b/test/utils/configurationVault/getConfiguration.spec.js
@@ -18,13 +18,21 @@ describe('getConfiguration', () => {
       expect(Conf).toHaveBeenCalledWith({
         projectName: 'gitmoji',
         schema: {
-          [CONFIG.AUTO_ADD]: { type: 'boolean' },
+          [CONFIG.AUTO_ADD]: { type: 'boolean', default: false },
           [CONFIG.EMOJI_FORMAT]: {
-            enum: Object.values(EMOJI_COMMIT_FORMATS)
+            enum: Object.values(EMOJI_COMMIT_FORMATS),
+            default: 'code'
           },
-          [CONFIG.SCOPE_PROMPT]: { type: 'boolean' },
-          [CONFIG.MESSAGE_PROMPT]: { type: 'boolean' },
-          [CONFIG.GITMOJIS_URL]: { type: 'string', format: 'url' }
+          [CONFIG.SCOPE_PROMPT]: {
+            type: 'boolean',
+            default: false
+          },
+          [CONFIG.MESSAGE_PROMPT]: { type: 'boolean', default: true },
+          [CONFIG.GITMOJIS_URL]: {
+            type: 'string',
+            format: 'url',
+            default: 'https://gitmoji.dev/api/gitmojis'
+          }
         }
       })
     })

--- a/test/utils/configurationVault/getConfiguration.spec.js
+++ b/test/utils/configurationVault/getConfiguration.spec.js
@@ -23,6 +23,7 @@ describe('getConfiguration', () => {
             enum: Object.values(EMOJI_COMMIT_FORMATS)
           },
           [CONFIG.SCOPE_PROMPT]: { type: 'boolean' },
+          [CONFIG.MESSAGE_PROMPT]: { type: 'boolean' },
           [CONFIG.GITMOJIS_URL]: { type: 'string', format: 'url' }
         }
       })
@@ -52,6 +53,12 @@ describe('getConfiguration', () => {
           const configuration = getConfiguration()
 
           expect(configuration.get('from')).toEqual('package.json')
+        })
+
+        it('should fallback to default config value if not set', () => {
+          const configuration = getConfiguration()
+
+          expect(configuration.get(CONFIG.MESSAGE_PROMPT)).toEqual(true)
         })
       })
 
@@ -89,6 +96,12 @@ describe('getConfiguration', () => {
 
           expect(configuration.get('from')).toEqual('rc')
         })
+
+        it('should fallback to default config value if not set', () => {
+          const configuration = getConfiguration()
+
+          expect(configuration.get(CONFIG.MESSAGE_PROMPT)).toEqual(true)
+        })
       })
 
       describe('when file is empty', () => {
@@ -114,6 +127,12 @@ describe('getConfiguration', () => {
 
         expect(configuration.get('from')).toEqual('local-cli')
       })
+
+      it('should fallback to default config value if not set', () => {
+        const configuration = getConfiguration()
+
+        expect(configuration.get(CONFIG.MESSAGE_PROMPT)).toEqual(true)
+      })
     })
 
     describe('when no configuration is available', () => {
@@ -128,6 +147,7 @@ describe('getConfiguration', () => {
         expect(configuration.get('autoAdd')).toEqual(false)
         expect(configuration.get('emojiFormat')).toEqual('code')
         expect(configuration.get('scopePrompt')).toEqual(false)
+        expect(configuration.get('messagePrompt')).toEqual(true)
         expect(configuration.get('gitmojisUrl')).toEqual(
           'https://gitmoji.dev/api/gitmojis'
         )

--- a/test/utils/configurationVault/vault.spec.js
+++ b/test/utils/configurationVault/vault.spec.js
@@ -51,6 +51,19 @@ describe('index > vault', () => {
       )
     })
 
+    it('should set and return value for messagePrompt', () => {
+      configurationVault.setMessagePrompt(false)
+      configurationVault.getMessagePrompt()
+
+      expect(getConfiguration().set).toHaveBeenCalledWith(
+        CONFIG.MESSAGE_PROMPT,
+        false
+      )
+      expect(getConfiguration().get).toHaveBeenCalledWith(
+        CONFIG.MESSAGE_PROMPT
+      )
+    })
+
     it('should set and return value for gitmojisUrl', () => {
       const testGitmojisUrl = 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
       configurationVault.setGitmojisUrl(testGitmojisUrl)


### PR DESCRIPTION
## Description

This PR updates the configuration vault, adding new functions to manage message and scope prompts. Most of the time you don't need a commit body and only need the title for quick commits. So to improve UX allow the user to disable that option so it only prompts for a gitmoji and title.

## Tests

- [x] All tests passed.
