### PR TITLE
✨ Expose flags as subcommands

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ updateNotifier({ pkg: JSON.parse(packageJson) }).notify({ isGlobal: true })
 const cli = meow(
   `
   Usage
-    $ gitmoji
+    $ gitmoji [option] [command]
   Options
     --${FLAGS.COMMIT}, -c    Interactively commit using the prompts
     --${FLAGS.CONFIG}, -g    Setup gitmoji-cli preferences.
@@ -27,6 +27,14 @@ const cli = meow(
     --${FLAGS.SEARCH}, -s    Search gitmojis
     --${FLAGS.UPDATE}, -u    Sync emoji list with the repo
     --${FLAGS.VERSION}, -v   Print gitmoji-cli installed version
+  Commands
+    commit          Interactively commit using the prompts
+    config          Setup gitmoji-cli preferences.
+    init            Initialize gitmoji as a commit hook
+    list            List all the available gitmojis
+    remove          Remove a previously initialized commit hook
+    search          Search gitmojis
+    update          Sync emoji list with the repo
   Examples
     $ gitmoji -l
     $ gitmoji bug linter -s

--- a/src/utils/findGitmojiCommand.js
+++ b/src/utils/findGitmojiCommand.js
@@ -2,6 +2,10 @@
 import COMMIT_MODES from '@constants/commit'
 import FLAGS from '@constants/flags'
 
+const isSupportedCommand = (command: ?string, options: Object): boolean => {
+  return Object.keys(options).includes(command)
+}
+
 const getOptionsForCommand = (command: ?string, flags: Object): ?Object => {
   const commandsWithOptions = [FLAGS.COMMIT, FLAGS.HOOK]
 
@@ -19,14 +23,25 @@ const getOptionsForCommand = (command: ?string, flags: Object): ?Object => {
 
 const findGitmojiCommand = (cli: any, options: Object): void => {
   const flags = cli.flags
-  const commandFlag = Object.keys(flags)
+
+  // Attempt to get the command out of the flags
+  let command = Object.keys(flags)
     .map((flag) => flags[flag] && flag)
     .find((flag) => options[flag])
-  const commandOptions = getOptionsForCommand(commandFlag, flags)
 
-  return options[commandFlag]
-    ? options[commandFlag](commandOptions)
-    : cli.showHelp()
+  if (!command && cli.input.length) {
+    // See if the user provided the command as a subcommand
+    command = cli.input[0]
+  }
+
+  // Unable to determine requested command so display help
+  if (!command || !isSupportedCommand(command, options)) {
+    return cli.showHelp()
+  }
+
+  const commandOptions = getOptionsForCommand(command, flags)
+
+  return options[command] ? options[command](commandOptions) : cli.showHelp()
 }
 
 export default findGitmojiCommand

--- a/src/utils/findGitmojiCommand.js
+++ b/src/utils/findGitmojiCommand.js
@@ -24,17 +24,11 @@ const getOptionsForCommand = (command: ?string, flags: Object): ?Object => {
 const findGitmojiCommand = (cli: any, options: Object): void => {
   const flags = cli.flags
 
-  // Attempt to get the command out of the flags
-  let command = Object.keys(flags)
-    .map((flag) => flags[flag] && flag)
-    .find((flag) => options[flag])
+  const command =
+    Object.keys(flags)
+      .map((flag) => flags[flag] && flag)
+      .find((flag) => options[flag]) || cli.input[0]
 
-  if (!command && cli.input.length) {
-    // See if the user provided the command as a subcommand
-    command = cli.input[0]
-  }
-
-  // Unable to determine requested command so display help
   if (!command || !isSupportedCommand(command, options)) {
     return cli.showHelp()
   }

--- a/test/__snapshots__/cli.spec.js.snap
+++ b/test/__snapshots__/cli.spec.js.snap
@@ -5,7 +5,7 @@ exports[`cli should match meow with cli information 1`] = `
   [
     "
   Usage
-    $ gitmoji
+    $ gitmoji [option] [command]
   Options
     --commit, -c    Interactively commit using the prompts
     --config, -g    Setup gitmoji-cli preferences.
@@ -15,6 +15,14 @@ exports[`cli should match meow with cli information 1`] = `
     --search, -s    Search gitmojis
     --update, -u    Sync emoji list with the repo
     --version, -v   Print gitmoji-cli installed version
+  Commands
+    commit          Interactively commit using the prompts
+    config          Setup gitmoji-cli preferences.
+    init            Initialize gitmoji as a commit hook
+    list            List all the available gitmojis
+    remove          Remove a previously initialized commit hook
+    search          Search gitmojis
+    update          Sync emoji list with the repo
   Examples
     $ gitmoji -l
     $ gitmoji bug linter -s

--- a/test/utils/findGitmojiCommand.spec.js
+++ b/test/utils/findGitmojiCommand.spec.js
@@ -6,20 +6,38 @@ import * as stubs from './stubs'
 describe('findGitmojiCommand', () => {
   stubs.commands.map((command) => {
     if ([FLAGS.COMMIT, FLAGS.HOOK].includes(command)) {
-      it(`it should match ${command} command`, () => {
-        findGitmojiCommand(stubs.cliMock({ [command]: true }), stubs.optionsMock)
-        expect(stubs.optionsMock[command]).toHaveBeenCalledWith({
-          mode: command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
-          message: undefined,
-          scope: undefined,
-          title: undefined,
+      describe(`with ${command}`, () => {
+        it(`it should match command`, () => {
+          findGitmojiCommand(
+            stubs.cliMock({ [command]: true }),
+            stubs.optionsMock
+          )
+          expect(stubs.optionsMock[command]).toHaveBeenCalledWith({
+            mode:
+              command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
+            message: undefined,
+            scope: undefined,
+            title: undefined
+          })
         })
       })
     }
 
-    it(`it should match ${command} command`, () => {
-      findGitmojiCommand(stubs.cliMock({ [command]: true }), stubs.optionsMock)
-      expect(stubs.optionsMock[command]).toHaveBeenCalled()
+    describe('with options', () => {
+      it(`it should match ${command} command`, () => {
+        findGitmojiCommand(
+          stubs.cliMock({ [command]: true }),
+          stubs.optionsMock
+        )
+        expect(stubs.optionsMock[command]).toHaveBeenCalled()
+      })
+    })
+
+    describe('with command', () => {
+      it(`it should match ${command} command`, () => {
+        findGitmojiCommand(stubs.cliMock({}, [command]), stubs.optionsMock)
+        expect(stubs.optionsMock[command]).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/test/utils/findGitmojiCommand.spec.js
+++ b/test/utils/findGitmojiCommand.spec.js
@@ -4,40 +4,36 @@ import COMMIT_MODES from '../../src/constants/commit'
 import * as stubs from './stubs'
 
 describe('findGitmojiCommand', () => {
-  stubs.commands.map((command) => {
-    if ([FLAGS.COMMIT, FLAGS.HOOK].includes(command)) {
-      describe(`with ${command}`, () => {
-        it(`it should match command`, () => {
-          findGitmojiCommand(
-            stubs.cliMock({ [command]: true }),
-            stubs.optionsMock
-          )
-          expect(stubs.optionsMock[command]).toHaveBeenCalledWith({
-            mode:
-              command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
-            message: undefined,
-            scope: undefined,
-            title: undefined
-          })
-        })
-      })
-    }
+  describe('with option', () => {
+    test.each(stubs.commands)('it should match %s option', (command) => {
+      findGitmojiCommand(stubs.cliMock({ [command]: true }), stubs.optionsMock)
+      expect(stubs.optionsMock[command]).toHaveBeenCalled()
+    })
+  })
 
-    describe('with options', () => {
-      it(`it should match ${command} command`, () => {
+  describe('with command', () => {
+    test.each(stubs.commands)('it should match %s command', (command) => {
+      findGitmojiCommand(stubs.cliMock({}, [command]), stubs.optionsMock)
+      expect(stubs.optionsMock[command]).toHaveBeenCalled()
+    })
+  })
+
+  describe('with specific command', () => {
+    test.each([FLAGS.COMMIT, FLAGS.HOOK])(
+      'it should have been called with',
+      (command) => {
         findGitmojiCommand(
           stubs.cliMock({ [command]: true }),
           stubs.optionsMock
         )
-        expect(stubs.optionsMock[command]).toHaveBeenCalled()
-      })
-    })
-
-    describe('with command', () => {
-      it(`it should match ${command} command`, () => {
-        findGitmojiCommand(stubs.cliMock({}, [command]), stubs.optionsMock)
-        expect(stubs.optionsMock[command]).toHaveBeenCalled()
-      })
-    })
+        expect(stubs.optionsMock[command]).toHaveBeenCalledWith({
+          mode:
+            command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
+          message: undefined,
+          scope: undefined,
+          title: undefined
+        })
+      }
+    )
   })
 })

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -9,7 +9,8 @@ export const commands = [
   'update'
 ]
 
-export const cliMock = (options) => ({
+export const cliMock = (options, input?: string[]) => ({
+  input: input || [],
   flags: {
     commit: options.commit || false,
     config: options.config || false,


### PR DESCRIPTION
## Description

This PR introduces the usage of subcommands alongside the usual flags. This means now eg. `gitmoji commit` is now usable as well as `gitmoji -c`.

Issue: #1070 

## Tests

- [x] All tests passed.
