### PR TITLE
🐛 Filter out `search` from query when using subcommands

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -62,7 +62,7 @@ export const options = ({
   [FLAGS.INIT]: () => commands.createHook(),
   [FLAGS.LIST]: () => commands.list(),
   [FLAGS.REMOVE]: () => commands.removeHook(),
-  [FLAGS.SEARCH]: () => cli.input.map((input) => commands.search(input)),
+  [FLAGS.SEARCH]: (options: Object) => commands.search(options),
   [FLAGS.UPDATE]: () => commands.update()
 }: { [$Values<typeof FLAGS>]: Function })
 

--- a/src/commands/search/index.js
+++ b/src/commands/search/index.js
@@ -3,10 +3,21 @@ import filterGitmojis from '@utils/filterGitmojis'
 import getEmojis from '@utils/getEmojis'
 import printEmojis from '@utils/printEmojis'
 
-const search = (query: string): Promise<void> => {
+type SearchOptions = {
+  query?: string[]
+}
+
+const search = (options: SearchOptions): Promise<void> => {
   return getEmojis()
-    .then((gitmojis) => filterGitmojis(query, gitmojis))
-    .then((gitmojisFiltered) => printEmojis(gitmojisFiltered))
+    .then((gitmojis) => {
+      if (!options.query) {
+        return printEmojis(gitmojis)
+      }
+
+      for (const query of options.query) {
+        printEmojis(filterGitmojis(query, gitmojis))
+      }
+    })
     .catch((err) => console.error(err))
 }
 

--- a/src/utils/findGitmojiCommand.js
+++ b/src/utils/findGitmojiCommand.js
@@ -6,34 +6,66 @@ const isSupportedCommand = (command: ?string, options: Object): boolean => {
   return Object.keys(options).includes(command)
 }
 
-const getOptionsForCommand = (command: ?string, flags: Object): ?Object => {
-  const commandsWithOptions = [FLAGS.COMMIT, FLAGS.HOOK]
+const determineCommand = (
+  flags: Object,
+  input: string[],
+  options: Object
+): {
+  type: 'flag' | 'command',
+  command: ?string
+} => {
+  const command = Object.keys(flags)
+    .map((flag) => flags[flag] && flag)
+    .find((flag) => options[flag])
 
-  if (commandsWithOptions.includes(command)) {
-    return {
-      message: flags['message'],
-      mode: command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
-      scope: flags['scope'],
-      title: flags['title']
-    }
+  return command
+    ? {
+        type: 'flag',
+        command
+      }
+    : {
+        type: 'command',
+        command: input[0]
+      }
+}
+
+const getOptionsForCommand = (
+  command: ?string,
+  flags: Object,
+  input: string[],
+  type: 'flag' | 'command'
+): ?Object => {
+  switch (command) {
+    case FLAGS.COMMIT:
+    case FLAGS.HOOK:
+      return {
+        message: flags['message'],
+        mode: command === FLAGS.HOOK ? COMMIT_MODES.HOOK : COMMIT_MODES.CLIENT,
+        scope: flags['scope'],
+        title: flags['title']
+      }
+    case FLAGS.SEARCH:
+      return {
+        query: type === 'command' ? input.slice(1) : input
+      }
   }
 
   return null
 }
 
 const findGitmojiCommand = (cli: any, options: Object): void => {
-  const flags = cli.flags
-
-  const command =
-    Object.keys(flags)
-      .map((flag) => flags[flag] && flag)
-      .find((flag) => options[flag]) || cli.input[0]
+  const { command, type } = determineCommand(cli.flags, cli.input, options)
 
   if (!command || !isSupportedCommand(command, options)) {
     return cli.showHelp()
   }
 
-  const commandOptions = getOptionsForCommand(command, flags)
+  const commandOptions = getOptionsForCommand(
+    command,
+    cli.flags,
+    cli.input,
+    type
+  )
 
   return options[command] ? options[command](commandOptions) : cli.showHelp()
 }

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -52,12 +52,12 @@ describe('cli', () => {
   })
 
   it('should call search command on search', () => {
-    options.search()
-    expect(commands.search).toHaveBeenCalledWith('testSearchQuery')
+    options.search({ query: ['testSearchQuery'] })
+    expect(commands.search).toHaveBeenCalledWith({ query: ['testSearchQuery'] })
   })
 
   it('should call update command on update', () => {
     options.update()
-    expect(commands.search).toHaveBeenCalledWith('testSearchQuery')
+    expect(commands.update).toHaveBeenCalledWith()
   })
 })

--- a/test/commands/search.spec.js
+++ b/test/commands/search.spec.js
@@ -11,7 +11,7 @@ describe('search command', () => {
   beforeAll(() => {
     console.log = jest.fn()
     getEmojis.mockResolvedValue(stubs.gitmojis)
-    search(stubs.searchQuery)
+    search({ query: [stubs.searchQuery] })
   })
 
   it('should call getEmojis', () => {

--- a/test/utils/findGitmojiCommand.spec.js
+++ b/test/utils/findGitmojiCommand.spec.js
@@ -35,5 +35,15 @@ describe('findGitmojiCommand', () => {
         })
       }
     )
+
+    it('should exclude subcommand from search query', () => {
+      findGitmojiCommand(
+        stubs.cliMock({}, [FLAGS.SEARCH, stubs.searchQuery]),
+        stubs.optionsMock
+      )
+      expect(stubs.optionsMock.search).toHaveBeenCalledWith({
+        query: [stubs.searchQuery]
+      })
+    })
   })
 })

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -417,3 +417,5 @@ export const relativeCoreHooksPath = '.git/hooks'
 
 export const hooksPath =
   '/Users/carloscuesta/GitHub/gitmoji-cli/.git/hooks/prepare-commit-msg'
+
+export const searchQuery = 'LoVe'


### PR DESCRIPTION
## Description

With the introduction of the subcommand when you use `gitmoji search bug linter` it will always include the `search` keyword in the query which is a regression. This PR ensures the `search` input is filtered out of `cli.input` when the command is executed through a subcommand.

It changes how the `search` command is handled. Instead of going over each input from within `cli.js` we now determine it in `findGitmojiCommand` and pass the correct option to the command depending on the situation. Where it is then further handled by the `search` command itself.

## Tests

- [x] All tests passed.
