### PR TITLE
📝 Mention correct default value for message prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If no user configuration is found, a set of default values will be used.
     "autoAdd": false,
     "emojiFormat": "code | emoji",
     "scopePrompt": false,
-    "messagePrompt": false,
+    "messagePrompt": true,
     "gitmojisUrl": "https://gitmoji.dev/api/gitmojis"
   }
 }
@@ -160,7 +160,7 @@ If no user configuration is found, a set of default values will be used.
   "autoAdd": false,
   "emojiFormat": "code | emoji" ,
   "scopePrompt": false,
-  "messagePrompt": false,
+  "messagePrompt": true,
   "gitmojisUrl": "https://gitmoji.dev/api/gitmojis"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The cli has some built-in configuration options that you can tweak at your own p
 - **Automatic git add**: Enable or disable the automatic `git add .` every time you use the commit command.
 - **Emoji format**: Switch between the emoji format.
 - **Scope prompt**: Enable or disable [conventional commits scope prompt](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+- **Message prompt**: Enable or disable the message prompt to only rely on the title prompt.
 - **Gitmojis api URL**: Set a custom URL to use it as the library of gitmojis.
 
 You can configure these options via (in order of precedence):


### PR DESCRIPTION
## Description

With the introduction of the message prompt the new default values were added to the `README` but with incorrect values. Not sure if intentional but might be better to reflect the actual default values.

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
