### PR TITLE
🚑 Don't include `undefined` in message body

### DIFF
--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -23,7 +23,7 @@ export type Answers = {
   gitmoji: string,
   scope?: string,
   title: string,
-  message: string
+  message?: string
 }
 
 export default (

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -26,13 +26,19 @@ const withClient = async (answers: Answers): Promise<void> => {
 
     if (isAutoAddEnabled) await execa('git', ['add', '.'])
 
-    const args = ['commit', isAutoAddEnabled ? '-am' : '-m', title]
-    if (answers.message) args.push('-m', answers.message)
-
-    await execa('git', args, {
-      buffer: false,
-      stdio: 'inherit'
-    })
+    await execa(
+      'git',
+      [
+        'commit',
+        isAutoAddEnabled ? '-am' : '-m',
+        title,
+        ...(answers.message ? ['-m', answers.message] : [])
+      ],
+      {
+        buffer: false,
+        stdio: 'inherit'
+      }
+    )
   } catch (error) {
     console.error(
       chalk.red(

--- a/src/commands/commit/withClient/index.js
+++ b/src/commands/commit/withClient/index.js
@@ -26,14 +26,13 @@ const withClient = async (answers: Answers): Promise<void> => {
 
     if (isAutoAddEnabled) await execa('git', ['add', '.'])
 
-    await execa(
-      'git',
-      ['commit', isAutoAddEnabled ? '-am' : '-m', title, '-m', answers.message],
-      {
-        buffer: false,
-        stdio: 'inherit'
-      }
-    )
+    const args = ['commit', isAutoAddEnabled ? '-am' : '-m', title]
+    if (answers.message) args.push('-m', answers.message)
+
+    await execa('git', args, {
+      buffer: false,
+      stdio: 'inherit'
+    })
   } catch (error) {
     console.error(
       chalk.red(

--- a/src/commands/commit/withHook/index.js
+++ b/src/commands/commit/withHook/index.js
@@ -8,7 +8,9 @@ const withHook = (answers: Answers) => {
   try {
     const scope = answers.scope ? `(${answers.scope}): ` : ''
     const title = `${answers.gitmoji} ${scope}${answers.title}`
-    const commitMessage = `${title}\n\n${answers.message}`
+    const commitMessage = `${title}${
+      answers.message ? `\n\n${answers.message}` : ''
+    }`
 
     fs.writeFileSync(process.argv[3], commitMessage)
   } catch (error) {


### PR DESCRIPTION
## Description

Didn't think about checking the code flow coming after the prompts but apparently we're still writing `undefined` to the message body if the prompt didn't pass anything. So now we only include the message body if it was provided in the prompt.

## Tests

- [x] All tests passed.
