### PR TITLE
✨ Allow user to disable capitalized titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ If no user configuration is found, a set of default values will be used.
     "emojiFormat": "code | emoji",
     "scopePrompt": false,
     "messagePrompt": false,
+    "capitalizeTitle": true,
     "gitmojisUrl": "https://gitmoji.dev/api/gitmojis"
   }
 }
@@ -162,6 +163,7 @@ If no user configuration is found, a set of default values will be used.
   "emojiFormat": "code | emoji" ,
   "scopePrompt": false,
   "messagePrompt": false,
+  "capitalizeTitle": true,
   "gitmojisUrl": "https://gitmoji.dev/api/gitmojis"
 }
 ```

--- a/src/commands/commit/index.js
+++ b/src/commands/commit/index.js
@@ -1,6 +1,7 @@
 // @flow
 import inquirer from 'inquirer'
 
+import configurationVault from '@utils/configurationVault'
 import getEmojis from '@utils/getEmojis'
 import COMMIT_MODES from '@constants/commit'
 import withHook, {
@@ -28,7 +29,9 @@ const promptAndCommit = (options: CommitOptions): Function =>
       inquirer.prompt(questions).then((answers: Answers) => {
         const transformedAnswers = {
           ...answers,
-          title: capitalizeTitle(answers.title)
+          title: configurationVault.getCapitalizeTitle()
+            ? capitalizeTitle(answers.title)
+            : answers.title
         }
 
         if (options.mode === COMMIT_MODES.HOOK) {

--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -60,9 +60,11 @@ export default (
       message: 'Enter the commit title',
       validate: guard.title,
       transformer: (input: string) => {
-        return `[${
-          (title || input).length
-        }/${TITLE_MAX_LENGTH_COUNT}]: ${capitalizeTitle(input)}`
+        return `[${(title || input).length}/${TITLE_MAX_LENGTH_COUNT}]: ${
+          configurationVault.getCapitalizeTitle()
+            ? capitalizeTitle(input)
+            : input
+        }`
       },
       ...(title ? { default: title } : {})
     },

--- a/src/commands/config/index.js
+++ b/src/commands/config/index.js
@@ -11,6 +11,7 @@ const config = () => {
     configurationVault.setEmojiFormat(answers[CONFIG.EMOJI_FORMAT])
     configurationVault.setScopePrompt(answers[CONFIG.SCOPE_PROMPT])
     configurationVault.setMessagePrompt(answers[CONFIG.MESSAGE_PROMPT])
+    configurationVault.setCapitalizeTitle(answers[CONFIG.CAPITALIZE_TITLE])
     configurationVault.setGitmojisUrl(answers[CONFIG.GITMOJIS_URL])
   })
 }

--- a/src/commands/config/prompts.js
+++ b/src/commands/config/prompts.js
@@ -33,6 +33,12 @@ export default (): Array<Object> => [
     default: configurationVault.getMessagePrompt()
   },
   {
+    name: CONFIG.CAPITALIZE_TITLE,
+    message: 'Capitalize title',
+    type: 'confirm',
+    default: configurationVault.getCapitalizeTitle()
+  },
+  {
     name: CONFIG.GITMOJIS_URL,
     message: 'Set gitmojis api url',
     type: 'input',

--- a/src/constants/configuration.js
+++ b/src/constants/configuration.js
@@ -3,7 +3,8 @@ export const CONFIG = {
   EMOJI_FORMAT: 'emojiFormat',
   SCOPE_PROMPT: 'scopePrompt',
   GITMOJIS_URL: 'gitmojisUrl',
-  MESSAGE_PROMPT: 'messagePrompt'
+  MESSAGE_PROMPT: 'messagePrompt',
+  CAPITALIZE_TITLE: 'capitalizeTitle'
 }
 
 export const EMOJI_COMMIT_FORMATS = {

--- a/src/utils/configurationVault/getConfiguration.js
+++ b/src/utils/configurationVault/getConfiguration.js
@@ -10,6 +10,7 @@ const DEFAULT_CONFIGURATION = {
   [CONFIG.EMOJI_FORMAT]: EMOJI_COMMIT_FORMATS.CODE,
   [CONFIG.SCOPE_PROMPT]: false,
   [CONFIG.MESSAGE_PROMPT]: true,
+  [CONFIG.CAPITALIZE_TITLE]: true,
   [CONFIG.GITMOJIS_URL]: 'https://gitmoji.dev/api/gitmojis'
 }
 
@@ -31,6 +32,10 @@ const LOCAL_CONFIGURATION: typeof Conf = new Conf({
     [CONFIG.MESSAGE_PROMPT]: {
       type: 'boolean',
       default: DEFAULT_CONFIGURATION[CONFIG.MESSAGE_PROMPT]
+    },
+    [CONFIG.CAPITALIZE_TITLE]: {
+      type: 'boolean',
+      default: DEFAULT_CONFIGURATION[CONFIG.CAPITALIZE_TITLE]
     },
     [CONFIG.GITMOJIS_URL]: {
       type: 'string',

--- a/src/utils/configurationVault/index.js
+++ b/src/utils/configurationVault/index.js
@@ -20,6 +20,10 @@ const setMessagePrompt = (messagePrompt: boolean): void => {
   configuration.set(CONFIG.MESSAGE_PROMPT, messagePrompt)
 }
 
+const setCapitalizeTitle = (capitalizeTitle: boolean): void => {
+  configuration.set(CONFIG.CAPITALIZE_TITLE, capitalizeTitle)
+}
+
 const setGitmojisUrl = (gitmojisUrl: string): void => {
   configuration.set(CONFIG.GITMOJIS_URL, gitmojisUrl)
 }
@@ -40,6 +44,10 @@ const getMessagePrompt = (): boolean => {
   return configuration.get(CONFIG.MESSAGE_PROMPT)
 }
 
+const getCapitalizeTitle = (): boolean => {
+  return configuration.get(CONFIG.CAPITALIZE_TITLE)
+}
+
 const getGitmojisUrl = (): string => {
   return configuration.get(CONFIG.GITMOJIS_URL)
 }
@@ -49,10 +57,12 @@ export default {
   getEmojiFormat,
   getScopePrompt,
   getMessagePrompt,
+  getCapitalizeTitle,
   getGitmojisUrl,
   setAutoAdd,
   setEmojiFormat,
   setScopePrompt,
   setMessagePrompt,
+  setCapitalizeTitle,
   setGitmojisUrl
 }

--- a/test/commands/config.spec.js
+++ b/test/commands/config.spec.js
@@ -31,6 +31,9 @@ describe('config command', () => {
     expect(configurationVault.setMessagePrompt).toHaveBeenCalledWith(
       stubs.configAnswers.messagePrompt
     )
+    expect(configurationVault.setCapitalizeTitle).toHaveBeenCalledWith(
+      stubs.configAnswers.capitalizeTitle
+    )
     expect(configurationVault.setGitmojisUrl).toHaveBeenCalledWith(
       stubs.configAnswers.gitmojisUrl
     )

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -1,4 +1,4 @@
-import { GITMOJIS_URL } from "../../src/utils/configurationVault"
+import { GITMOJIS_URL } from '../../src/utils/configurationVault'
 
 export const gitmojis = [
   {
@@ -23,6 +23,7 @@ export const configAnswers = {
   signedCommit: true,
   scopePrompt: false,
   messagePrompt: true,
+  capitalizeTitle: true,
   gitmojisUrl: GITMOJIS_URL
 }
 

--- a/test/utils/configurationVault/__snapshots__/defaults.spec.js.snap
+++ b/test/utils/configurationVault/__snapshots__/defaults.spec.js.snap
@@ -3,11 +3,13 @@
 exports[`index should match the module 1`] = `
 {
   "getAutoAdd": [Function],
+  "getCapitalizeTitle": [Function],
   "getEmojiFormat": [Function],
   "getGitmojisUrl": [Function],
   "getMessagePrompt": [Function],
   "getScopePrompt": [Function],
   "setAutoAdd": [Function],
+  "setCapitalizeTitle": [Function],
   "setEmojiFormat": [Function],
   "setGitmojisUrl": [Function],
   "setMessagePrompt": [Function],

--- a/test/utils/configurationVault/getConfiguration.spec.js
+++ b/test/utils/configurationVault/getConfiguration.spec.js
@@ -28,6 +28,7 @@ describe('getConfiguration', () => {
             default: false
           },
           [CONFIG.MESSAGE_PROMPT]: { type: 'boolean', default: true },
+          [CONFIG.CAPITALIZE_TITLE]: { type: 'boolean', default: true },
           [CONFIG.GITMOJIS_URL]: {
             type: 'string',
             format: 'url',
@@ -156,6 +157,7 @@ describe('getConfiguration', () => {
         expect(configuration.get('emojiFormat')).toEqual('code')
         expect(configuration.get('scopePrompt')).toEqual(false)
         expect(configuration.get('messagePrompt')).toEqual(true)
+        expect(configuration.get('capitalizeTitle')).toEqual(true)
         expect(configuration.get('gitmojisUrl')).toEqual(
           'https://gitmoji.dev/api/gitmojis'
         )

--- a/test/utils/configurationVault/vault.spec.js
+++ b/test/utils/configurationVault/vault.spec.js
@@ -1,14 +1,13 @@
 import configurationVault from '@utils/configurationVault'
 import getConfiguration from '@utils/configurationVault/getConfiguration'
-import {
-  CONFIG,
-  EMOJI_COMMIT_FORMATS
-} from '@constants/configuration'
+import { CONFIG, EMOJI_COMMIT_FORMATS } from '@constants/configuration'
 
-jest.mock('@utils/configurationVault/getConfiguration', () => jest.fn().mockReturnValue({
-  set: jest.fn(),
-  get: jest.fn()
-}))
+jest.mock('@utils/configurationVault/getConfiguration', () =>
+  jest.fn().mockReturnValue({
+    set: jest.fn(),
+    get: jest.fn()
+  })
+)
 
 describe('index > vault', () => {
   describe('setter and getters', () => {
@@ -16,13 +15,8 @@ describe('index > vault', () => {
       configurationVault.setAutoAdd(true)
       configurationVault.getAutoAdd()
 
-      expect(getConfiguration().set).toHaveBeenCalledWith(
-        CONFIG.AUTO_ADD,
-        true
-      )
-      expect(getConfiguration().get).toHaveBeenCalledWith(
-        CONFIG.AUTO_ADD,
-      )
+      expect(getConfiguration().set).toHaveBeenCalledWith(CONFIG.AUTO_ADD, true)
+      expect(getConfiguration().get).toHaveBeenCalledWith(CONFIG.AUTO_ADD)
     })
 
     it('should set and return value for emojiFormat', () => {
@@ -33,9 +27,7 @@ describe('index > vault', () => {
         CONFIG.EMOJI_FORMAT,
         EMOJI_COMMIT_FORMATS.EMOJI
       )
-      expect(getConfiguration().get).toHaveBeenCalledWith(
-        CONFIG.EMOJI_FORMAT
-      )
+      expect(getConfiguration().get).toHaveBeenCalledWith(CONFIG.EMOJI_FORMAT)
     })
 
     it('should set and return value for scopePrompt', () => {
@@ -46,9 +38,7 @@ describe('index > vault', () => {
         CONFIG.SCOPE_PROMPT,
         true
       )
-      expect(getConfiguration().get).toHaveBeenCalledWith(
-        CONFIG.SCOPE_PROMPT
-      )
+      expect(getConfiguration().get).toHaveBeenCalledWith(CONFIG.SCOPE_PROMPT)
     })
 
     it('should set and return value for messagePrompt', () => {
@@ -59,13 +49,25 @@ describe('index > vault', () => {
         CONFIG.MESSAGE_PROMPT,
         false
       )
+      expect(getConfiguration().get).toHaveBeenCalledWith(CONFIG.MESSAGE_PROMPT)
+    })
+
+    it('should set and return value for capitalizeTitle', () => {
+      configurationVault.setCapitalizeTitle(false)
+      configurationVault.getCapitalizeTitle()
+
+      expect(getConfiguration().set).toHaveBeenCalledWith(
+        CONFIG.CAPITALIZE_TITLE,
+        false
+      )
       expect(getConfiguration().get).toHaveBeenCalledWith(
-        CONFIG.MESSAGE_PROMPT
+        CONFIG.CAPITALIZE_TITLE
       )
     })
 
     it('should set and return value for gitmojisUrl', () => {
-      const testGitmojisUrl = 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
+      const testGitmojisUrl =
+        'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
       configurationVault.setGitmojisUrl(testGitmojisUrl)
       configurationVault.getGitmojisUrl()
 
@@ -73,9 +75,7 @@ describe('index > vault', () => {
         CONFIG.GITMOJIS_URL,
         testGitmojisUrl
       )
-      expect(getConfiguration().get).toHaveBeenCalledWith(
-        CONFIG.GITMOJIS_URL
-      )
+      expect(getConfiguration().get).toHaveBeenCalledWith(CONFIG.GITMOJIS_URL)
     })
   })
 })


### PR DESCRIPTION
## Description

I believe that the recently merged [capitalize feature](https://github.com/carloscuesta/gitmoji-cli/pull/1071) should be configurable through the static config file.

For instance, the [`Conventional Commits`](https://www.conventionalcommits.org/en/v1.0.0/#are-the-types-in-the-commit-title-uppercase-or-lowercase) standard does not mandate capitalizing the first letter of commit titles, but recommends maintaining consistency. However, it would be challenging to maintain consistency if lowercase titles were the default with this modification.

This pull request is addressing that issue. What is your opinion on it?

## Tests

- [x] All tests passed.
