### PR TITLE
💥 Bump Node.js minimum version to `v18`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "A gitmoji client for using emojis on commit messages.",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "bin": {
     "gitmoji": "lib/cli.js"


### PR DESCRIPTION
## Description

👋🏼 OC on title
 
