### PR TITLE
✨ Avoid text moving when nb char is 10

### DIFF
--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -60,7 +60,9 @@ export default (
       message: 'Enter the commit title',
       validate: guard.title,
       transformer: (input: string) => {
-        return `[${(title || input).length}/${TITLE_MAX_LENGTH_COUNT}]: ${
+        const nbChar = String((title || input).length).padStart(2)
+        
+        return `[${nbChar}/${TITLE_MAX_LENGTH_COUNT}]: ${
           configurationVault.getCapitalizeTitle()
             ? capitalizeTitle(input)
             : input

--- a/src/commands/commit/prompts.js
+++ b/src/commands/commit/prompts.js
@@ -60,9 +60,9 @@ export default (
       message: 'Enter the commit title',
       validate: guard.title,
       transformer: (input: string) => {
-        const nbChar = String((title || input).length).padStart(2)
+        const length = (title || input).length.toString().padStart(2, '0');
         
-        return `[${nbChar}/${TITLE_MAX_LENGTH_COUNT}]: ${
+        return `[${length}/${TITLE_MAX_LENGTH_COUNT}]: ${
           configurationVault.getCapitalizeTitle()
             ? capitalizeTitle(input)
             : input


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->

When you type a commit message, on the 10nth char, the text move one character to the right because the prompt title goes from `9/48` to `10/48`

```diff
- Enter the commit title [9/48]: 123456789
+ Enter the commit title [10/48]: 1234567890
```

This is pretty annoying, so a added a `padStart(2)` to avoid this effect


```diff
- Enter the commit title [09/48]: 123456789
+ Enter the commit title [10/48]: 1234567890
```

There will still be the same effect after 99, but it's an un-recommended number of chars, so we might ignore this.

## Tests

<!-- Ensure that all the tests passed -->
- [ ] All tests passed.
