### PR TITLE
♻️ Maintenance: Improve TypeScript support

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,6 +15,7 @@ module.name_mapper='^@utils\/\(.*\)$' -> '<PROJECT_ROOT>/src/utils/\1'
 module.name_mapper='^@constants\/\(.*\)$' -> '<PROJECT_ROOT>/src/constants/\1'
 module.name_mapper='^@commands\/\(.*\)$' -> '<PROJECT_ROOT>/src/commands/\1'
 exact_by_default=true
+module.file_ext=.ts
 
 [strict]
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -22,7 +22,7 @@
   },
   "overrides": [
     {
-      "test": ["./src/**/*.ts"],
+      "test": ["**/*.ts"],
       "presets": ["@babel/preset-typescript"]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -92,13 +92,18 @@
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "src/**/*.js"
+      "src/**/*.js",
+      "src/**/*.ts"
     ],
     "testMatch": [
-      "**/*.(spec).(js)"
+      "**/*.(spec).(js|ts)"
     ],
     "setupFiles": [
       "./test/setupTests.js"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "ts"
     ],
     "transformIgnorePatterns": [],
     "moduleNameMapper": {
@@ -106,7 +111,8 @@
       "^#supports-color$": "<rootDir>/node_modules/chalk/source/vendor/supports-color/index.js",
       "@utils/(.*)$": "<rootDir>/src/utils/$1",
       "@commands/(.*)$": "<rootDir>/src/commands/$1",
-      "@constants/(.*)$": "<rootDir>/src/constants/$1"
+      "@constants/(.*)$": "<rootDir>/src/constants/$1",
+      "^(\\.\\.?\\/.+)\\.js$": "$1"
     }
   },
   "prettier": {
@@ -124,22 +130,14 @@
     ],
     "env": {
       "es2021": true,
-      "node": true
+      "node": true,
+      "jest": true
     },
     "extends": [
       "eslint:recommended",
       "plugin:@typescript-eslint/recommended"
     ],
     "overrides": [
-      {
-        "files": [
-          "./**/*.spec.js",
-          "./**/*.spec.ts"
-        ],
-        "env": {
-          "jest": true
-        }
-      },
       {
         "files": [
           "./**/*.ts"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,10 +3,10 @@ import meow from 'meow'
 import updateNotifier from 'update-notifier'
 import { readFileSync } from 'fs'
 
-import FLAGS from '@constants/flags'
-import findGitmojiCommand from '@utils/findGitmojiCommand'
-import type { CommitOptions } from '@commands/commit'
-import type { SearchOptions } from '@commands/search'
+import FLAGS from '@constants/flags.js'
+import findGitmojiCommand from '@utils/findGitmojiCommand.js'
+import type { CommitOptions } from '@commands/commit/index.js'
+import type { SearchOptions } from '@commands/search/index.js'
 
 const packageJson = readFileSync(
   new URL('../package.json', import.meta.url)
@@ -59,19 +59,21 @@ const cli = meow(
 
 export const options = {
   [FLAGS.COMMIT]: async (options: CommitOptions) =>
-    await (await import('@commands/commit')).default(options),
+    await (await import('@commands/commit/index.js')).default(options),
   [FLAGS.CONFIG]: async () =>
-    await (await import('@commands/config')).default(),
+    await (await import('@commands/config/index.js')).default(),
   [FLAGS.HOOK]: async (options: CommitOptions) =>
-    await (await import('@commands/commit')).default(options),
+    await (await import('@commands/commit/index.js')).default(options),
   [FLAGS.INIT]: async () =>
-    await (await import('@commands/hook')).default.create(),
-  [FLAGS.LIST]: async () => await (await import('@commands/list')).default(),
+    await (await import('@commands/hook/index.js')).default.create(),
+  [FLAGS.LIST]: async () =>
+    await (await import('@commands/list/index.js')).default(),
   [FLAGS.REMOVE]: async () =>
-    await (await import('@commands/hook')).default.remove(),
+    await (await import('@commands/hook/index.js')).default.remove(),
   [FLAGS.SEARCH]: async (options: SearchOptions) =>
-    await (await import('@commands/search')).default(options),
-  [FLAGS.UPDATE]: async () => await (await import('@commands/update')).default()
+    await (await import('@commands/search/index.js')).default(options),
+  [FLAGS.UPDATE]: async () =>
+    await (await import('@commands/update/index.js')).default()
 }
 
 findGitmojiCommand(cli, options)

--- a/src/commands/commit/withClient/index.ts
+++ b/src/commands/commit/withClient/index.ts
@@ -1,10 +1,9 @@
-// @flow
 import { execa } from 'execa'
 import chalk from 'chalk'
 
-import isHookCreated from '@utils/isHookCreated'
-import configurationVault from '@utils/configurationVault'
-import { type Answers } from '../prompts'
+import isHookCreated from '@utils/isHookCreated.js'
+import configurationVault from '@utils/configurationVault/index.js'
+import { type Answers } from '../prompts.js'
 
 const withClient = async (answers: Answers): Promise<void> => {
   try {

--- a/test/__snapshots__/cli.spec.ts.snap
+++ b/test/__snapshots__/cli.spec.ts.snap
@@ -30,39 +30,39 @@ exports[`cli should match meow with cli information 1`] = `
     {
       "flags": {
         "commit": {
-          "alias": "c",
+          "shortFlag": "c",
           "type": "boolean",
         },
         "config": {
-          "alias": "g",
+          "shortFlag": "g",
           "type": "boolean",
         },
         "help": {
-          "alias": "h",
+          "shortFlag": "h",
           "type": "boolean",
         },
         "init": {
-          "alias": "i",
+          "shortFlag": "i",
           "type": "boolean",
         },
         "list": {
-          "alias": "l",
+          "shortFlag": "l",
           "type": "boolean",
         },
         "remove": {
-          "alias": "r",
+          "shortFlag": "r",
           "type": "boolean",
         },
         "search": {
-          "alias": "s",
+          "shortFlag": "s",
           "type": "boolean",
         },
         "update": {
-          "alias": "u",
+          "shortFlag": "u",
           "type": "boolean",
         },
         "version": {
-          "alias": "v",
+          "shortFlag": "v",
           "type": "boolean",
         },
       },

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -2,8 +2,8 @@ import updateNotifier from 'update-notifier'
 import meow from 'meow'
 
 import pkg from '../package.json'
-import { options } from '../src/cli'
-import commands from '../src/commands'
+import { options } from '../src/cli.js'
+import commands from '../src/commands/index.js'
 
 jest.mock('../src/commands')
 

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,11 +1,22 @@
 import updateNotifier from 'update-notifier'
 import meow from 'meow'
 
+import commit from '@commands/commit/index.js'
+import config from '@commands/config/index.js'
+import hook from '@commands/hook/index.js'
+import list from '@commands/list/index.js'
+import search from '@commands/search/index.js'
+import update from '@commands/update/index.js'
+
 import pkg from '../package.json'
 import { options } from '../src/cli.js'
-import commands from '../src/commands/index.js'
 
-jest.mock('../src/commands')
+jest.mock('@commands/commit/index.js')
+jest.mock('@commands/config/index.js')
+jest.mock('@commands/hook/index.js')
+jest.mock('@commands/list/index.js')
+jest.mock('@commands/search/index.js')
+jest.mock('@commands/update/index.js')
 
 describe('cli', () => {
   it('should call updateNotifier', () => {
@@ -16,50 +27,48 @@ describe('cli', () => {
   })
 
   it('should match meow with cli information', () => {
-    (
-      (meow as jest.Mock).mock.calls[0][1] as { importMeta: string }
-    ).importMeta = 'import.meta.url'
-
-    expect((meow as jest.Mock).mock.calls).toMatchSnapshot()
+    const mockMeow = meow as jest.Mock
+    mockMeow.mock.calls[0][1].importMeta = 'import.meta.url'
+    expect(mockMeow.mock.calls).toMatchSnapshot()
   })
 
-  it('should call commit command on commit', () => {
-    options.commit({ mode: 'client' })
-    expect(commands.commit).toHaveBeenCalledWith({ mode: 'client' })
+  it('should call commit command on commit', async () => {
+    await options.commit({ mode: 'client' })
+    expect(commit).toHaveBeenCalledWith({ mode: 'client' })
   })
 
-  it('should call config command on config', () => {
-    options.config()
-    expect(commands.config).toHaveBeenCalledWith()
+  it('should call config command on config', async () => {
+    await options.config()
+    expect(config).toHaveBeenCalledWith()
   })
 
-  it('should call commit command on hook', () => {
-    options.hook({ mode: 'hook' })
-    expect(commands.commit).toHaveBeenLastCalledWith({ mode: 'hook' })
+  it('should call commit command on hook', async () => {
+    await options.hook({ mode: 'hook' })
+    expect(commit).toHaveBeenLastCalledWith({ mode: 'hook' })
   })
 
-  it('should call createHook command on init', () => {
-    options.init()
-    expect(commands.createHook).toHaveBeenCalledWith()
+  it('should call createHook command on init', async () => {
+    await options.init()
+    expect(hook.create).toHaveBeenCalledWith()
   })
 
-  it('should call list command on list', () => {
-    options.list()
-    expect(commands.list).toHaveBeenCalledWith()
+  it('should call list command on list', async () => {
+    await options.list()
+    expect(list).toHaveBeenCalledWith()
   })
 
-  it('should call removeHook command on remove', () => {
-    options.remove()
-    expect(commands.removeHook).toHaveBeenCalledWith()
+  it('should call removeHook command on remove', async () => {
+    await options.remove()
+    expect(hook.remove).toHaveBeenCalledWith()
   })
 
-  it('should call search command on search', () => {
-    options.search({ query: ['testSearchQuery'] })
-    expect(commands.search).toHaveBeenCalledWith({ query: ['testSearchQuery'] })
+  it('should call search command on search', async () => {
+    await options.search({ query: ['testSearchQuery'] })
+    expect(search).toHaveBeenCalledWith({ query: ['testSearchQuery'] })
   })
 
-  it('should call update command on update', () => {
-    options.update()
-    expect(commands.update).toHaveBeenCalledWith()
+  it('should call update command on update', async () => {
+    await options.update()
+    expect(update).toHaveBeenCalledWith()
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "baseUrl": "./",
     "paths": {
       "@utils/*": ["src/utils/*"],


### PR DESCRIPTION
## Description

After reading reports from people trying their hand on converting files to TS, I noticed the setup wasn't fully allowing conversion without causing a big waterfall of required changes. While it was already possible to import Flow files into TS, it apparently wasn't yet possible to import TS files into Flow without the need for a lot of changes. This PR basically attempts to fix whatever was needed so proper TS work can start again 🚀

### Changed

- Adjusted `babel` to properly handle all `.ts` files and not just the ones in `./src`
- Adjusted `tsconfig.json` to properly output ESM so it can be used alongside other ESM modules like `meow` and `execa`
- `withClient.ts` has been converted to TS 

### Fixed

- Jest now properly looks for `.ts` files and includes them in the test run
- `cli.spec.ts` has not been running since the original TS introduction and is now running again

Issue: https://github.com/carloscuesta/gitmoji-cli/issues/1110#issuecomment-1996843360

## Tests

- [x] All tests passed.
