### PR TITLE
📌 Limit inquirer to patch versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "conf": "12.0.0",
     "execa": "^8.0.1",
     "fuse.js": "7.0.0",
-    "inquirer": "^9.2.23",
+    "inquirer": "~9.2.23",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "meow": "^13.1.0",
     "node-fetch": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3485,7 +3485,7 @@ inquirer-autocomplete-prompt@^3.0.1:
     run-async "^2.4.1"
     rxjs "^7.5.6"
 
-inquirer@^9.2.23:
+inquirer@~9.2.23:
   version "9.2.23"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-9.2.23.tgz#cd2fe34edca12315b624fbc3c8cb99b1c4f61f90"
   integrity sha512-kod5s+FBPIDM2xiy9fu+6wdU/SkK5le5GS9lh4FEBjBHqiMgD9lLFbCbuqFNAjNL2ZOy9Wd9F694IOzN9pZHBA==


### PR DESCRIPTION
## Description

Seems like `inquirer` unified their monorepo setup and changed from a `lib` directory to `src` which is causing `inquirer-autocomplete-prompt` to fail since it has a peer dependency on an older version of `inquirer`. Package managers are bumping the version to `9.3.x` due to us having `^9.2.23`.

So we limit package managers to not update to minor version `9.3.x` for now. 

Issue: https://github.com/carloscuesta/gitmoji-cli/issues/1321

## Tests

- [x] All tests passed.
