### PR TITLE
:bug: Explicit wrap messages with quotes

### DIFF
--- a/src/commands/commit/withClient/index.ts
+++ b/src/commands/commit/withClient/index.ts
@@ -8,7 +8,7 @@ import { type Answers } from '../prompts.js'
 const withClient = async (answers: Answers): Promise<void> => {
   try {
     const scope = answers.scope ? `(${answers.scope}): ` : ''
-    const title = `${answers.gitmoji} ${scope}${answers.title}`
+    const title = `"${answers.gitmoji} ${scope}${answers.title}"`
     const isAutoAddEnabled = configurationVault.getAutoAdd()
 
     if (await isHookCreated()) {
@@ -30,9 +30,10 @@ const withClient = async (answers: Answers): Promise<void> => {
         'commit',
         isAutoAddEnabled ? '-am' : '-m',
         title,
-        ...(answers.message ? ['-m', answers.message] : [])
+        ...(answers.message ? ['-m', `"${answers.message}"`] : [])
       ],
       {
+        shell: true,
         buffer: false,
         stdio: 'inherit'
       }

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -46,11 +46,12 @@ describe('commit command', () => {
           [
             'commit',
             '-m',
-            `${stubs.clientCommitAnswers.gitmoji} ${stubs.clientCommitAnswers.title}`,
+            `"${stubs.clientCommitAnswers.gitmoji} ${stubs.clientCommitAnswers.title}"`,
             '-m',
-            stubs.clientCommitAnswers.message
+            `"${stubs.clientCommitAnswers.message}"`
           ],
           {
+            shell: true,
             buffer: false,
             stdio: 'inherit'
           }
@@ -87,11 +88,12 @@ describe('commit command', () => {
           [
             'commit',
             '-am',
-            `${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}`,
+            `"${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}"`,
             '-m',
-            stubs.clientCommitAnswersWithScope.message
+            `"${stubs.clientCommitAnswersWithScope.message}"`
           ],
           {
+            shell: true,
             buffer: false,
             stdio: 'inherit'
           }

--- a/test/commands/stubs.js
+++ b/test/commands/stubs.js
@@ -42,8 +42,8 @@ export const commitTitleInvalid = 'Invalid commit `title'
 
 export const clientCommitAnswers = {
   gitmoji: ':zap:',
-  title: 'Improving performance issues.',
-  message: 'Refactored code. Fixes #5'
+  title: '"Improving performance issues."',
+  message: '"Refactored code. Fixes #5"'
 }
 
 export const clientCommitAnswersWithScope = {


### PR DESCRIPTION
### Description
Fixes https://github.com/carloscuesta/gitmoji-cli/issues/1391. Not sure if this ever reported with quotes around the message but `execa` seems to automatically escape quotes and at one point it stopped working. 

### Added
- Added `shell: true` option to git commit execution

### Changed
- Updated commit message formatting to include quotes around both title and message parts
- Modified test stubs and expectations to match the new quoted format