### PR TITLE
fix(commit): remove shell:true to resolve DEP0190 on Node.js 24

### DIFF
--- a/src/commands/commit/withClient/index.ts
+++ b/src/commands/commit/withClient/index.ts
@@ -8,7 +8,7 @@ import { type Answers } from '../prompts.js'
 const withClient = async (answers: Answers): Promise<void> => {
   try {
     const scope = answers.scope ? `(${answers.scope}): ` : ''
-    const title = `"${answers.gitmoji} ${scope}${answers.title}"`
+    const title = `${answers.gitmoji} ${scope}${answers.title}`
     const isAutoAddEnabled = configurationVault.getAutoAdd()
 
     if (await isHookCreated()) {
@@ -30,10 +30,9 @@ const withClient = async (answers: Answers): Promise<void> => {
         'commit',
         isAutoAddEnabled ? '-am' : '-m',
         title,
-        ...(answers.message ? ['-m', `"${answers.message}"`] : [])
+        ...(answers.message ? ['-m', answers.message] : [])
       ],
       {
-        shell: true,
         buffer: false,
         stdio: 'inherit'
       }

--- a/test/commands/commit.spec.js
+++ b/test/commands/commit.spec.js
@@ -46,12 +46,11 @@ describe('commit command', () => {
           [
             'commit',
             '-m',
-            `"${stubs.clientCommitAnswers.gitmoji} ${stubs.clientCommitAnswers.title}"`,
+            `${stubs.clientCommitAnswers.gitmoji} ${stubs.clientCommitAnswers.title}`,
             '-m',
-            `"${stubs.clientCommitAnswers.message}"`
+            stubs.clientCommitAnswers.message
           ],
           {
-            shell: true,
             buffer: false,
             stdio: 'inherit'
           }
@@ -88,12 +87,11 @@ describe('commit command', () => {
           [
             'commit',
             '-am',
-            `"${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}"`,
+            `${stubs.clientCommitAnswersWithScope.gitmoji} (${stubs.clientCommitAnswersWithScope.scope}): ${stubs.clientCommitAnswersWithScope.title}`,
             '-m',
-            `"${stubs.clientCommitAnswersWithScope.message}"`
+            stubs.clientCommitAnswersWithScope.message
           ],
           {
-            shell: true,
             buffer: false,
             stdio: 'inherit'
           }


### PR DESCRIPTION
Node.js 24 emits DEP0190 when args are passed to a child process with `shell: true` because they are concatenated rather than escaped. Removing `shell: true` means `execa` passes each element of the args array directly to `git` as a separate argument, so the manual double-quotes around the title and body strings are no longer needed and have been removed.

Fixes the warning reported in #1491.